### PR TITLE
AppMetrics: move stopwatch initialization logic to be compatible with long running servers

### DIFF
--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -33,11 +33,6 @@ class AppMetrics implements MetricsGeneratorInterface
 
     public function init(string $namespace, CollectorRegistry $collectionRegistry)
     {
-        if (class_exists(self::STOPWATCH_CLASS)) {
-            $className = self::STOPWATCH_CLASS;
-            $this->stopwatch = new $className();
-            $this->stopwatch->start('execution_time');
-        }
         $this->namespace = $namespace;
         $this->collectionRegistry = $collectionRegistry;
     }
@@ -145,6 +140,12 @@ class AppMetrics implements MetricsGeneratorInterface
         // do not track "OPTIONS" requests
         if ('OPTIONS' === $requestMethod) {
             return;
+        }
+
+        if (class_exists(self::STOPWATCH_CLASS)) {
+            $className = self::STOPWATCH_CLASS;
+            $this->stopwatch = new $className();
+            $this->stopwatch->start('execution_time');
         }
 
         $this->setInstance($request->server->get('HOSTNAME') ?? 'dev');

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -102,11 +102,14 @@ class AppMetricsTest extends TestCase
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $reqEvt = $this->createMock(RequestEvent::class);
+        $reqEvt->expects(self::any())->method('getRequest')->willReturn($request);
         $evt = $this->createMock(TerminateEvent::class);
         $evt->expects(self::any())->method('getRequest')->willReturn($request);
         $response = new Response('', 200);
         $evt->expects(self::any())->method('getResponse')->willReturn($response);
 
+        $metrics->collectRequest($reqEvt);
         $metrics->collectResponse($evt);
         $response = $this->renderer->renderResponse();
         $content = $response->getContent();


### PR DESCRIPTION
Hi! 
First of all thanks for the bundle! I was using it and I recently switched our setup from Nginx + FPM to Swoole server. 
In doing that, I noticed several errors coming up that were like this

`[2020-06-19T14:51:22.358209+00:00] app.ERROR: stop() called but start() has not been called before. {"from":"response_collector","class":"Artprima\\PrometheusMetricsBundle\\Metrics\\AppMetrics"} {"user":null}
`

Upon further testing, I noticed that the stopwatch to measure request time was initialized in the init function. In a situation such as with Swoole (where the container and services are built only once and then stay in memory) this results in the same stopwatch instance being used for all requests, without being started again because `init` is called only once. 

Thus, I moved the initialization of the stopwatch to the onCollectRequest handler and this solved the issue for me.
I also had to update  AppMetricsTest because it was relying on the assumption that init would setup the stopwatch.

Let me know if I need to do something else for this PR to be merged, thanks again!