### PR TITLE
RequestCounter: raise priority to trigger earlier

### DIFF
--- a/Metrics/MetricsGeneratorInterface.php
+++ b/Metrics/MetricsGeneratorInterface.php
@@ -12,6 +12,8 @@ interface MetricsGeneratorInterface
 {
     public function init(string $namespace, CollectorRegistry $collectionRegistry);
 
+    public function collectStart(RequestEvent $event);
+
     public function collectRequest(RequestEvent $event);
 
     public function collectResponse(TerminateEvent $event);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,8 @@
     </service>
 
     <service id="Artprima\PrometheusMetricsBundle\EventListener\RequestCounterListener" class="Artprima\PrometheusMetricsBundle\EventListener\RequestCounterListener" public="true" autowire="false" autoconfigure="false">
-        <tag name="kernel.event_listener" event="kernel.request" priority="1024"/>
+        <tag name="kernel.event_listener" event="kernel.request"/>
+        <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequestPre" priority="1024"/>
         <tag name="kernel.event_listener" event="kernel.terminate"/>
         <argument type="service" id="Artprima\PrometheusMetricsBundle\Metrics\MetricsGeneratorRegistry"/>
         <call method="setLogger">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,7 +13,7 @@
     </service>
 
     <service id="Artprima\PrometheusMetricsBundle\EventListener\RequestCounterListener" class="Artprima\PrometheusMetricsBundle\EventListener\RequestCounterListener" public="true" autowire="false" autoconfigure="false">
-        <tag name="kernel.event_listener" event="kernel.request"/>
+        <tag name="kernel.event_listener" event="kernel.request" priority="1024"/>
         <tag name="kernel.event_listener" event="kernel.terminate"/>
         <argument type="service" id="Artprima\PrometheusMetricsBundle\Metrics\MetricsGeneratorRegistry"/>
         <call method="setLogger">

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -109,6 +109,7 @@ class AppMetricsTest extends TestCase
         $response = new Response('', 200);
         $evt->expects(self::any())->method('getResponse')->willReturn($response);
 
+        $metrics->collectStart($reqEvt);
         $metrics->collectRequest($reqEvt);
         $metrics->collectResponse($evt);
         $response = $this->renderer->renderResponse();


### PR DESCRIPTION
Hi again,

I've noticed that the RequestCounterListener has a default priority of 0 for the kernel.request handler.
As an example, this is the number of listeners for my application that uses Api Platform.

```
 ------- ---------------------------------------------------------------------------------------------- ---------- 
  Order   Callable                                                                                       Priority  
 ------- ---------------------------------------------------------------------------------------------- ---------- 
  #1      Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure()                  2048      
  #2      Symfony\Component\HttpKernel\EventListener\ValidateRequestListener::onKernelRequest()          256       
  #3      Nelmio\CorsBundle\EventListener\CorsListener::onKernelRequest()                                250       
  #4      Symfony\Component\HttpKernel\EventListener\SessionListener::onKernelRequest()                  128       
  #5      Symfony\Component\HttpKernel\EventListener\LocaleListener::setDefaultLocale()                  100       
  #6      App\EventSubscriber\ContextSubscriber::initializeContext()                             90        
  #7      Symfony\Component\HttpKernel\EventListener\RouterListener::onKernelRequest()                   32        
  #8      ApiPlatform\Core\Filter\QueryParameterValidateListener::onKernelRequest()                      16        
  #9      Symfony\Component\HttpKernel\EventListener\LocaleListener::onKernelRequest()                   16        
  #10     Symfony\Component\HttpKernel\EventListener\LocaleAwareListener::onKernelRequest()              15        
  #11     Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener::configureLogoutUrlGenerator()   8         
  #12     Symfony\Bundle\SecurityBundle\Debug\TraceableFirewallListener::onKernelRequest()               8         
  #13     ApiPlatform\Core\EventListener\AddFormatListener::onKernelRequest()                            7         
  #14     App\EventSubscriber\CacheEventSubscriber::preRead()                                            5         
  #15     App\EventSubscriber\MainEventSubscriber::preRead()                                             5         
  #16     ApiPlatform\Core\EventListener\ReadListener::onKernelRequest()                                 4         
  #17     ApiPlatform\Core\Security\EventListener\DenyAccessListener::onSecurity()                       3         
  #18     App\EventSubscriber\MainEventSubscriber::postRead()                                            3         
  #19     ApiPlatform\Core\EventListener\DeserializeListener::onKernelRequest()                          2         
  #20     ApiPlatform\Core\Security\EventListener\DenyAccessListener::onSecurityPostDenormalize()        1         
  #21     ApiPlatform\Core\Bridge\Symfony\Bundle\EventListener\SwaggerUiListener::onKernelRequest()      0         
  #22     Artprima\PrometheusMetricsBundle\EventListener\RequestCounterListener::onKernelRequest()       0         
 ------- ---------------------------------------------------------------------------------------------- ---------- 
     
 ------- ---------------------------------------------------------------------------------------------- ---------- 
```

As you can see, there is quite a lot going on even before the stopwatch is started (this now happens because the stopwatch is not started in the init method as per my previous PR). Because of this, the time measurement is not as accurate as it could be. Moreover, in my specific case I was also losing some timing of requests because one of my listeners set the response at this stage (from a cache).

Thus, I suggest raising the priority of the handler to 1024 so that it is basically fired as the first event (apart from the debug ones).