### PR TITLE
Issue with psr-4

### DIFF
--- a/Tests/BundleInMemoryTest.php
+++ b/Tests/BundleInMemoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Artprima\PrometheusMetricsBundle\Tests;
+namespace Tests\Artprima\PrometheusMetricsBundle;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\AppKernel;

--- a/Tests/BundleRedisTest.php
+++ b/Tests/BundleRedisTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Artprima\PrometheusMetricsBundle\Tests;
+namespace Tests\Artprima\PrometheusMetricsBundle;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\AppKernel;


### PR DESCRIPTION
Class Artprima\PrometheusMetricsBundle\Tests\BundleRedisTest located in ./vendor/artprima/prometheus-metrics-bundle/Tests/BundleRedistTest.php does not comply with psr-4 autoloading standard. Skipping.