### PR TITLE
Collect status code in label

### DIFF
--- a/.integration/symfony/tests/Functional/ArtprimaPrometheusBundleTest.php
+++ b/.integration/symfony/tests/Functional/ArtprimaPrometheusBundleTest.php
@@ -23,11 +23,11 @@ class ArtprimaPrometheusBundleTest extends WebTestCase
             trim($content)
         );
         self::assertContains(
-            'symfony_http_2xx_responses_total{action="GET-app_dummy_homepage"} 1'.PHP_EOL,
+            'symfony_http_2xx_responses_total{action="GET-app_dummy_homepage",status="200"} 1'.PHP_EOL,
             $content
         );
         self::assertContains(
-            'symfony_http_2xx_responses_total{action="all"} 1'.PHP_EOL,
+            'symfony_http_2xx_responses_total{action="all",status="200"} 1'.PHP_EOL,
             $content
         );
         self::assertContains(

--- a/.integration/symfony/tests/Functional/ArtprimaPrometheusBundleTest.php
+++ b/.integration/symfony/tests/Functional/ArtprimaPrometheusBundleTest.php
@@ -27,7 +27,7 @@ class ArtprimaPrometheusBundleTest extends WebTestCase
             $content
         );
         self::assertContains(
-            'symfony_http_2xx_responses_total{action="all",status="200"} 1'.PHP_EOL,
+            'symfony_http_2xx_responses_total{action="all",status="all"} 1'.PHP_EOL,
             $content
         );
         self::assertContains(

--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -126,7 +126,7 @@ class AppMetrics implements MetricsCollectorInterface
             sprintf('total %s response count', $type),
             ['action', 'status']
         );
-        $counter->inc(['all']);
+        $counter->inc(['all', 'all']);
 
         if (null !== $method && null !== $route && null !== $status) {
             $counter->inc([sprintf('%s-%s', $method, $route), $status]);

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -100,7 +100,7 @@ class AppMetricsTest extends TestCase
         $responseContent = $response->getContent();
 
         self::assertStringContainsString("dummy_{$metricsName}{action=\"all\",status=\"$code\"} 1\n", $responseContent);
-        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\",status=\"$code\"} 1\n", $responseContent);
+        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\",status=\"all\"} 1\n", $responseContent);
     }
 
     public function testSetRequestDuration(): void

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -99,8 +99,8 @@ class AppMetricsTest extends TestCase
         $response = $this->renderer->renderResponse();
         $responseContent = $response->getContent();
 
-        self::assertStringContainsString("dummy_{$metricsName}{action=\"all\"} 1\n", $responseContent);
-        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\"} 1\n", $responseContent);
+        self::assertStringContainsString("dummy_{$metricsName}{action=\"all\",status=\"$code\"} 1\n", $responseContent);
+        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\",status=\"$code\"} 1\n", $responseContent);
     }
 
     public function testSetRequestDuration(): void

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -99,8 +99,8 @@ class AppMetricsTest extends TestCase
         $response = $this->renderer->renderResponse();
         $responseContent = $response->getContent();
 
-        self::assertStringContainsString("dummy_{$metricsName}{action=\"all\",status=\"$code\"} 1\n", $responseContent);
-        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\",status=\"all\"} 1\n", $responseContent);
+        self::assertStringContainsString("dummy_{$metricsName}{action=\"all\",status=\"all\"} 1\n", $responseContent);
+        self::assertStringContainsString("dummy_{$metricsName}{action=\"GET-test_route\",status=\"$code\"} 1\n", $responseContent);
     }
 
     public function testSetRequestDuration(): void


### PR DESCRIPTION
Hey, thanks for this library!

This is a small change that would really go a long way IMO. 

While it's already good to know whether a request was successful (2xx/3xx) or failed (4xx/5xx), it would be better to be able to distinguish why it failed. E.g. a 404 is dramatically different from a 401 or 403.