### PR TITLE
interfaces and event listeners for console terminate and error

### DIFF
--- a/EventListener/MetricsCollectorListener.php
+++ b/EventListener/MetricsCollectorListener.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Artprima\PrometheusMetricsBundle\EventListener;
 
+use Artprima\PrometheusMetricsBundle\Metrics\ConsoleErrorMetricsCollectorInterface;
+use Artprima\PrometheusMetricsBundle\Metrics\ConsoleTerminateMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\ExceptionMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorRegistry;
@@ -157,6 +159,46 @@ class MetricsCollectorListener implements LoggerAwareInterface
 
             try {
                 $collector->collectResponse($event);
+            } catch (\Exception $e) {
+                if ($this->logger) {
+                    $this->logger->error(
+                        $e->getMessage(),
+                        ['from' => 'response_collector', 'class' => get_class($collector)]
+                    );
+                }
+            }
+        }
+    }
+
+    public function onConsoleTerminate($event)
+    {
+        foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
+            if (!self::isSupportedEvent($collector, 'collectConsole', ConsoleTerminateMetricsCollectorInterface::class)) {
+                continue;
+            }
+
+            try {
+                $collector->collectConsole($event);
+            } catch (\Exception $e) {
+                if ($this->logger) {
+                    $this->logger->error(
+                        $e->getMessage(),
+                        ['from' => 'response_collector', 'class' => get_class($collector)]
+                    );
+                }
+            }
+        }
+    }
+
+    public function onConsoleError($event)
+    {
+        foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
+            if (!self::isSupportedEvent($collector, 'collectConsoleError', ConsoleErrorMetricsCollectorInterface::class)) {
+                continue;
+            }
+
+            try {
+                $collector->collectConsoleError($event);
             } catch (\Exception $e) {
                 if ($this->logger) {
                     $this->logger->error(

--- a/Metrics/ConsoleErrorMetricsCollectorInterface.php
+++ b/Metrics/ConsoleErrorMetricsCollectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\Metrics;
+
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+
+/**
+ * ConsoleErrorMetricsCollectorInterface lets collecting metrics on "console.error" event.
+ */
+interface ConsoleErrorMetricsCollectorInterface extends MetricsCollectorInterface
+{
+    public function collectConsoleError(ConsoleErrorEvent $event): void;
+}

--- a/Metrics/ConsoleTerminateMetricsCollectorInterface.php
+++ b/Metrics/ConsoleTerminateMetricsCollectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\Metrics;
+
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+
+/**
+ * ConsoleTerminateMetricsCollectorInterface lets collecting metrics on "console.terminate" event.
+ */
+interface ConsoleTerminateMetricsCollectorInterface extends MetricsCollectorInterface
+{
+    public function collectConsole(ConsoleTerminateEvent $event): void;
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -18,6 +18,8 @@
         <tag name="kernel.event_listener" event="kernel.exception" method="onKernelExceptionPre" />
         <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="1024"/>
         <tag name="kernel.event_listener" event="kernel.terminate"/>
+        <tag name="kernel.event_listener" event="console.terminate" method="onConsoleTerminate"/>
+        <tag name="kernel.event_listener" event="console.error" method="onConsoleError"/>
         <argument type="service" id="Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorRegistry"/>
         <call method="setLogger">
             <argument type="service" id="logger" on-invalid="ignore"/>

--- a/Tests/EventListener/MetricsCollectorListenerTest.php
+++ b/Tests/EventListener/MetricsCollectorListenerTest.php
@@ -5,16 +5,24 @@ declare(strict_types=1);
 namespace Tests\Artprima\PrometheusMetricsBundle\EventListener;
 
 use Artprima\PrometheusMetricsBundle\EventListener\MetricsCollectorListener;
+use Artprima\PrometheusMetricsBundle\Metrics\ConsoleErrorMetricsCollectorInterface;
+use Artprima\PrometheusMetricsBundle\Metrics\ConsoleTerminateMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorRegistry;
 use Artprima\PrometheusMetricsBundle\Metrics\RequestMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\TerminateMetricsCollectorInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleErrorEvent;
+use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ErrorHandler\BufferingLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Throwable;
 
 class MetricsCollectorListenerTest extends TestCase
 {
@@ -176,5 +184,49 @@ class MetricsCollectorListenerTest extends TestCase
 
         $listener = new MetricsCollectorListener($registry);
         $listener->onKernelTerminate($evt);
+    }
+
+    public function testOnConsoleTerminate(): void
+    {
+        $evt = new ConsoleTerminateEvent(
+            $this->createMock(Command::class),
+            $this->createMock(InputInterface::class),
+            $this->createMock(OutputInterface::class),
+            0
+        );
+
+        $collector1 = $this->createMock(ConsoleTerminateMetricsCollectorInterface::class);
+        $collector1->expects(self::once())->method('collectConsole')->with($evt);
+        $collector2 = $this->createMock(ConsoleTerminateMetricsCollectorInterface::class);
+        $collector2->expects(self::once())->method('collectConsole')->with($evt);
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($collector1);
+        $registry->registerMetricsCollector($collector2);
+
+        $listener = new MetricsCollectorListener($registry);
+        $listener->onConsoleTerminate($evt);
+    }
+
+    public function testOnConsoleError(): void
+    {
+        $evt = new ConsoleErrorEvent(
+            $this->createMock(InputInterface::class),
+            $this->createMock(OutputInterface::class),
+            $this->createMock(Throwable::class),
+            $this->createMock(Command::class)
+        );
+
+        $collector1 = $this->createMock(ConsoleErrorMetricsCollectorInterface::class);
+        $collector1->expects(self::once())->method('collectConsoleError')->with($evt);
+        $collector2 = $this->createMock(ConsoleErrorMetricsCollectorInterface::class);
+        $collector2->expects(self::once())->method('collectConsoleError')->with($evt);
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($collector1);
+        $registry->registerMetricsCollector($collector2);
+
+        $listener = new MetricsCollectorListener($registry);
+        $listener->onConsoleError($evt);
     }
 }


### PR DESCRIPTION
allow to hook into `console.terminate` and `console.error` for metric collection.

solves #44 