### PR TITLE
Add console command to clear metrics (#33)

### DIFF
--- a/Command/ClearMetricsCommand.php
+++ b/Command/ClearMetricsCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * Clear metrics from prometheus storage
+ * Clear metrics from prometheus storage.
  */
 class ClearMetricsCommand extends Command
 {
@@ -22,9 +22,6 @@ class ClearMetricsCommand extends Command
     private $storage;
 
 
-    /**
-     * @param Adapter $storage
-     */
     public function __construct(Adapter $storage)
     {
         parent::__construct(static::$defaultName);

--- a/Command/ClearMetricsCommand.php
+++ b/Command/ClearMetricsCommand.php
@@ -21,7 +21,6 @@ class ClearMetricsCommand extends Command
      */
     private $storage;
 
-
     public function __construct(Adapter $storage)
     {
         parent::__construct(static::$defaultName);

--- a/Command/ClearMetricsCommand.php
+++ b/Command/ClearMetricsCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\Command;
+
+use Prometheus\Storage\Adapter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Clear metrics from prometheus storage
+ */
+class ClearMetricsCommand extends Command
+{
+    protected static $defaultName = 'artprima:prometheus:metrics:clear';
+
+    /**
+     * @var Adapter
+     */
+    private $storage;
+
+
+    /**
+     * @param Adapter $storage
+     */
+    public function __construct(Adapter $storage)
+    {
+        parent::__construct(static::$defaultName);
+
+        $this->storage = $storage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription('Clear all collected metrics from storage')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln(sprintf('Clearing storage from <comment>%s</comment>', get_class($this->storage)));
+
+        $this->storage->wipeStorage();
+
+        $output->writeln('<success>The storage was successfully cleared.</success>');
+
+        return 0;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@ by the built-in class `Artprima\PrometheusMetricsBundle\Metrics`. Here, in the e
 and the metrics show a single request to the root named `app_dummy_homepage`. Symfony instance is named `dev` here.
 Instance name comes from the server var `HOSTNAME` (`$request->server->get('HOSTNAME')`) and defaults to `dev`.
 
+Clear Metrics
+=============
+
+The bundle provides a console command to clear metrics from the storage. Simply run:
+```bash
+./bin/console artprima:prometheus:metrics:clear
+```
+
 Code license
 ============
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -41,5 +41,11 @@
     <service id="Artprima\PrometheusMetricsBundle\Controller\MetricsController" class="Artprima\PrometheusMetricsBundle\Controller\MetricsController" public="true" autowire="false" autoconfigure="false">
         <argument type="service" id="Artprima\PrometheusMetricsBundle\Metrics\Renderer"/>
     </service>
+
+    <!-- Register commands -->
+    <service id="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand" class="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand">
+        <argument type="service" id="prometheus_metrics_bundle.adapter"/>
+        <tag name="console.command"  command="artprima:prometheus:metrics:clear"/>
+    </service>
 </services>
 </container>

--- a/Tests/BundleInMemoryTest.php
+++ b/Tests/BundleInMemoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Artprima\PrometheusMetricsBundle;
 
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\AppKernel;
 
@@ -19,6 +21,18 @@ class BundleInMemoryTest extends WebTestCase
         $client->request('GET', '/metrics/prometheus');
         self::assertStringContainsString('myapp_instance_name{instance="dev"} 1', $client->getResponse()->getContent());
         self::assertStringContainsString('php_info{version=', $client->getResponse()->getContent());
+    }
+
+    public function testClearCommand(): void
+    {
+        $client = self::createClient(['test_case' => 'PrometheusMetricsBundle', 'root_config' => 'config_in_memory.yml']);
+        $application = new Application(static::$kernel);
+
+        $tester = new CommandTester($application->get('artprima:prometheus:metrics:clear'));
+        $tester->execute([]);
+
+        $client->request('GET', '/metrics/prometheus');
+        self::assertStringContainsString('', $client->getResponse()->getContent());
     }
 
     protected static function getKernelClass(): string

--- a/Tests/Command/ClearMetricsCommandTest.php
+++ b/Tests/Command/ClearMetricsCommandTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\Command;
+
+use Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\Adapter;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ *
+ */
+class ClearMetricsCommandTest extends TestCase
+{
+    /**
+     *
+     */
+    public function testClear()
+    {
+        $adapter = $this->createMock(Adapter::class);
+        $adapter->expects($this->once())->method('wipeStorage');
+        $className = get_class($adapter);
+
+        $command = new ClearMetricsCommand($adapter);
+        $application = new Application();
+        $application->add($command);
+
+        $tester = new CommandTester($application->get('artprima:prometheus:metrics:clear'));
+        $tester->execute([]);
+
+        $expected = <<<EOL
+Clearing storage from {$className}
+<success>The storage was successfully cleared.</success>
+
+EOL;
+
+        $this->assertSame($expected, $tester->getDisplay());
+    }
+
+}

--- a/Tests/Command/ClearMetricsCommandTest.php
+++ b/Tests/Command/ClearMetricsCommandTest.php
@@ -33,5 +33,4 @@ EOL;
 
         $this->assertSame($expected, $tester->getDisplay());
     }
-
 }

--- a/Tests/Command/ClearMetricsCommandTest.php
+++ b/Tests/Command/ClearMetricsCommandTest.php
@@ -10,14 +10,8 @@ use Prometheus\Storage\Adapter;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- *
- */
 class ClearMetricsCommandTest extends TestCase
 {
-    /**
-     *
-     */
     public function testClear()
     {
         $adapter = $this->createMock(Adapter::class);


### PR DESCRIPTION
This PR provides a simple console command to clear metrics from the storage.
```bash
./bin/console artprima:prometheus:metrics:clear
```