### PR TITLE
Add storage adapter factory (#51) (#55) (#61) (#64)

### DIFF
--- a/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
+++ b/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
@@ -4,40 +4,32 @@ declare(strict_types=1);
 
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection\Compiler;
 
-use Prometheus\Storage\APC;
-use Prometheus\Storage\InMemory;
-use Prometheus\Storage\Redis;
+use Artprima\PrometheusMetricsBundle\StorageFactory\FactoryRegistry;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\PriorityTaggedServiceTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
- * ResolveAdapterDefinitionPass is a compilation pass that sets the metrics backend storage adapter.
+ * ResolveAdapterDefinitionPass is a compilation pass that register factories of adapter.
  */
 class ResolveAdapterDefinitionPass implements CompilerPassInterface
 {
+    use PriorityTaggedServiceTrait;
+
+    const TAG_NAME = 'prometheus_metrics_bundle.adapter_factory';
+
     public function process(ContainerBuilder $container)
     {
-        if (!$container->hasDefinition('prometheus_metrics_bundle.adapter')) {
+        if (!$container->hasDefinition(FactoryRegistry::class)) {
             return;
         }
 
-        $adapterClasses = [
-            'in_memory' => InMemory::class,
-            'apcu' => APC::class,
-            'redis' => Redis::class,
-        ];
-
-        $definition = $container->getDefinition('prometheus_metrics_bundle.adapter');
-        $definition->setAbstract(false);
-        $definition->setClass($adapterClasses[$container->getParameter('prometheus_metrics_bundle.type')]);
-        if ('redis' === $container->getParameter('prometheus_metrics_bundle.type')) {
-            $redisArguments = $container->getParameter('prometheus_metrics_bundle.redis');
-            $prefix = $redisArguments['prefix'] ?? null;
-            if (!empty($prefix)) {
-                $definition->addMethodCall('setPrefix', [$prefix]);
-                unset($redisArguments['prefix']);
-            }
-            $definition->setArguments([$redisArguments]);
+        if (!$factories = $this->findAndSortTaggedServices(self::TAG_NAME, $container)) {
+            throw new RuntimeException(sprintf('You must tag at least one service as "%s" to use the "%s" service.', self::TAG_NAME, FactoryRegistry::class));
         }
+
+        $factoryRegistry = $container->getDefinition(FactoryRegistry::class);
+        $factoryRegistry->replaceArgument(0, $factories);
     }
 }

--- a/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
+++ b/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
- * ResolveAdapterDefinitionPass is a compilation pass that register factories of adapter.
+ * ResolveAdapterDefinitionPass is a compilation pass that registers adapter factories.
  */
 class ResolveAdapterDefinitionPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -25,6 +26,17 @@ class Configuration implements ConfigurationInterface
         $supportedTypes = ['in_memory', 'apcu', 'redis'];
 
         $rootNode
+            // Manage deprecated parameter "type": will be transform as storage.url
+            ->beforeNormalization()
+                ->ifTrue(static function ($v) {
+                    return !empty($v['type']) && empty($v['storage']);
+                })
+                ->then(static function ($v) {
+                    $v['storage'] = ['type' => $v['type']];
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('namespace')
                     ->isRequired()
@@ -38,6 +50,9 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('type')
+                    ->setDeprecated(
+                        ...$this->getDeprecationMsg('The type config parameter was deprecated in 1.14 and will be dropped in 2.0.', '1.14')
+                    )
                     ->validate()
                         ->ifNotInArray($supportedTypes)
                         ->thenInvalid('The type %s is not supported. Please choose one of '.json_encode($supportedTypes))
@@ -46,6 +61,9 @@ class Configuration implements ConfigurationInterface
                     ->cannotBeEmpty()
                 ->end()
                 ->arrayNode('redis')
+                    ->setDeprecated(
+                        ...$this->getDeprecationMsg('The redis config parameter was deprecated in 1.14 and will be dropped in 2.0.', '1.14')
+                    )
                     ->children()
                         ->scalarNode('host')->end()
                         ->integerNode('port')
@@ -76,6 +94,51 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+                ->arrayNode('storage')
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(static function ($v) {
+                            return ['url' => $v];
+                        })
+                    ->end()
+                    ->validate()
+                        ->always()
+                        ->then(static function ($v) {
+                            if (empty($v['options'])) {
+                                unset($v['options']);
+                            }
+
+                            return $v;
+                        })
+                    ->end()
+                    ->fixXmlConfig('option')
+                    ->children()
+                        ->scalarNode('url')->info('DSN of the storage. All parsed values will override explicitly set parameters. Ex: redis://127.0.0.1?timeout=0.1')->end()
+                        ->scalarNode('type')->info('The type of storage provide by factories. Default factories are '.json_encode($supportedTypes))->end()
+                        ->scalarNode('host')->info('Use by some factory like redis. Default value should be managed by the factory at runtime.')->end()
+                        ->integerNode('port')->info('Use by some factory like redis. Default value should be managed by the factory at runtime.')->end()
+                        ->floatNode('timeout')->info('Connection timeout used by some factory like redis.')->end()
+                        ->floatNode('read_timeout')->end()
+                        ->booleanNode('persistent_connections')->end()
+                        ->scalarNode('password')->end()
+                        ->integerNode('database')->end()
+                        ->scalarNode('prefix')
+                            ->info('Internal prefix used by the storage. Available for redis and apcu type.')
+                            ->cannotBeEmpty()
+                            ->validate()
+                                ->ifTrue(function ($s) {
+                                    return 1 !== preg_match('/^[a-zA-Z_:][a-zA-Z0-9_:]*$/', $s);
+                                })
+                                ->thenInvalid('Invalid prefix. Make sure it matches the following regex: ^[a-zA-Z_:][a-zA-Z0-9_:]*$')
+                            ->end()
+                        ->end()
+                        ->arrayNode('options')
+                            ->info('Custom factory could use this parameter to add more parameters.')
+                            ->useAttributeAsKey('key')
+                            ->prototype('variable')->end()
+                        ->end()
+                    ->end()
+                ->end()
                 ->arrayNode('ignored_routes')
                     ->prototype('scalar')->end()
                     ->defaultValue(['prometheus_bundle_prometheus'])
@@ -96,5 +159,21 @@ class Configuration implements ConfigurationInterface
         // more information on that topic.
 
         return $treeBuilder;
+    }
+
+    /**
+     * Returns the correct deprecation param's as an array for setDeprecated.
+     */
+    private function getDeprecationMsg(string $message, string $version): array
+    {
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return [
+                'artprima/prometheus-metrics-bundle',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,7 +6,11 @@
     <parameter key="prometheus_metrics_bundle.collector_registry.class">Prometheus\CollectorRegistry</parameter>
 </parameters>
 <services>
-    <service id="prometheus_metrics_bundle.adapter" class="Prometheus\Storage\Adapter" abstract="true" public="false" autowire="false" autoconfigure="false" />
+    <service id="prometheus_metrics_bundle.adapter" class="Prometheus\Storage\Adapter" public="false" autowire="false" autoconfigure="false">
+        <factory service="Artprima\PrometheusMetricsBundle\StorageFactory\FactoryRegistry"
+                 method="create"/>
+        <argument type="collection"/>
+    </service>
 
     <service id="prometheus_metrics_bundle.collector_registry" class="%prometheus_metrics_bundle.collector_registry.class%" public="false" autowire="false" autoconfigure="false">
         <argument type="service" id="prometheus_metrics_bundle.adapter" />
@@ -46,6 +50,27 @@
     <service id="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand" class="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand">
         <argument type="service" id="prometheus_metrics_bundle.adapter"/>
         <tag name="console.command"  command="artprima:prometheus:metrics:clear"/>
+    </service>
+
+    <!-- Register storage fatories -->
+    <service id="Artprima\PrometheusMetricsBundle\StorageFactory\FactoryRegistry"
+             class="Artprima\PrometheusMetricsBundle\StorageFactory\FactoryRegistry">
+        <argument type="collection"/>
+    </service>
+
+    <service id="Artprima\PrometheusMetricsBundle\StorageFactory\RedisFactory"
+             class="Artprima\PrometheusMetricsBundle\StorageFactory\RedisFactory">
+        <tag name="prometheus_metrics_bundle.adapter_factory" />
+    </service>
+
+    <service id="Artprima\PrometheusMetricsBundle\StorageFactory\InMemoryFactory"
+             class="Artprima\PrometheusMetricsBundle\StorageFactory\InMemoryFactory">
+        <tag name="prometheus_metrics_bundle.adapter_factory" />
+    </service>
+
+    <service id="Artprima\PrometheusMetricsBundle\StorageFactory\ApcFactory"
+             class="Artprima\PrometheusMetricsBundle\StorageFactory\ApcFactory">
+        <tag name="prometheus_metrics_bundle.adapter_factory" />
     </service>
 </services>
 </container>

--- a/StorageFactory/ApcFactory.php
+++ b/StorageFactory/ApcFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Prometheus\Storage\Adapter;
+use Prometheus\Storage\APC;
+
+class ApcFactory implements StorageFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return APC
+     */
+    public function create(array $options): Adapter
+    {
+        return new APC($options['prefix'] ?? APC::PROMETHEUS_PREFIX);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return 'apcu';
+    }
+}

--- a/StorageFactory/FactoryRegistry.php
+++ b/StorageFactory/FactoryRegistry.php
@@ -66,7 +66,7 @@ class FactoryRegistry
         $options = parse_url($dsn);
 
         if (false === $options) {
-            throw new InvalidArgumentException('Invalid DSN.');
+            throw new InvalidArgumentException(sprintf('Invalid DSN %s.', $dsn));
         }
 
         $options = array_map('rawurldecode', $options);

--- a/StorageFactory/FactoryRegistry.php
+++ b/StorageFactory/FactoryRegistry.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use InvalidArgumentException;
+use Prometheus\Storage\Adapter;
+
+class FactoryRegistry
+{
+    /**
+     * @var StorageFactoryInterface[]
+     */
+    private $factories;
+
+    /**
+     * @param StorageFactoryInterface[] $factories
+     */
+    public function __construct(array $factories = [])
+    {
+        foreach ($factories as $factory) {
+            $this->register($factory);
+        }
+    }
+
+    /**
+     * Register a custom factory.
+     */
+    public function register(StorageFactoryInterface $factory): void
+    {
+        $this->factories[$factory->getName()] = $factory;
+    }
+
+    /**
+     * Gets the registered factory by the name and create the adapter.
+     */
+    public function create(array $options): Adapter
+    {
+        if (isset($options['url'])) {
+            $options = array_merge($options, $this->parseDsn($options['url']));
+            $options['type'] = $options['scheme'];
+            unset($options['url'], $options['scheme']);
+        }
+
+        if (!($name = $options['type'] ?? false) || !isset($this->factories[$name])) {
+            throw new InvalidArgumentException('The scheme of the adapter is not defined. Could not find factory for "'.$name.'"');
+        }
+
+        return $this->factories[$name]->create($options);
+    }
+
+    /**
+     * Parse the dsn string and returns the array key.
+     *
+     * @see parse_url()
+     */
+    private function parseDsn(string $dsn): array
+    {
+        // Only parsing dsn as url: legacy use case.
+        // This will manage non url value as scheme.
+        if (false === strpos($dsn, ':')) {
+            return ['scheme' => $dsn];
+        }
+
+        $options = parse_url($dsn);
+
+        if (false === $options) {
+            throw new InvalidArgumentException('Invalid DSN.');
+        }
+
+        $options = array_map('rawurldecode', $options);
+
+        // Manage the "driver:var1=value1;var2=value2" synthax.
+        if (isset($options['path']) && !isset($options['query']) && false !== strpos($options['path'], ';')) {
+            $options['query'] = str_replace(';', '&', $options['path']);
+            unset($options['path']);
+        }
+
+        // Parse the query string as additionnal options.
+        if (isset($options['query'])) {
+            $query = [];
+            parse_str($options['query'], $query);
+            $options = array_merge($options, $query);
+            unset($options['query']);
+        }
+
+        if (isset($options['path'])) {
+            $options['path'] = trim((string) $options['path'], '/');
+        }
+
+        if (isset($options['port'])) {
+            $options['port'] = (int) $options['port'];
+        }
+
+        return $options;
+    }
+}

--- a/StorageFactory/InMemoryFactory.php
+++ b/StorageFactory/InMemoryFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Prometheus\Storage\Adapter;
+use Prometheus\Storage\InMemory;
+
+class InMemoryFactory implements StorageFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return InMemory
+     */
+    public function create(array $options): Adapter
+    {
+        return new InMemory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return 'in_memory';
+    }
+}

--- a/StorageFactory/RedisFactory.php
+++ b/StorageFactory/RedisFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Prometheus\Storage\Adapter;
+use Prometheus\Storage\Redis;
+
+class RedisFactory implements StorageFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @return Redis
+     */
+    public function create(array $options): Adapter
+    {
+        if (isset($options['pass'])) {
+            $options['password'] = $options['pass'];
+            unset($options['pass']);
+        }
+
+        if (isset($options['path'])) {
+            $options['database'] = (int) $options['path'];
+            unset($options['path']);
+        } elseif (isset($options['database'])) {
+            $options['database'] = (int) $options['database'];
+        }
+
+        if (isset($options['prefix'])) {
+            Redis::setPrefix($options['prefix']);
+            unset($options['prefix']);
+        }
+
+        if (isset($options['persistent_connections'])) {
+            $options['persistent_connections'] = filter_var($options['persistent_connections'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        // Cast read_timeout option to avoid TypeError when working with Redis
+        // see for more details: https://github.com/phpredis/phpredis/issues/1538
+        if (isset($options['read_timeout'])) {
+            $options['read_timeout'] = (string) $options['read_timeout'];
+        }
+
+        // The timeout option is cast to float in Redis class.
+        return new Redis($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return 'redis';
+    }
+}

--- a/StorageFactory/StorageFactoryInterface.php
+++ b/StorageFactory/StorageFactoryInterface.php
@@ -6,6 +6,10 @@ namespace Artprima\PrometheusMetricsBundle\StorageFactory;
 
 use Prometheus\Storage\Adapter;
 
+/**
+ * StorageFactoryInterface provides a way to create instance of @Prometheus\Storage\Adapter.
+ * A storage factory should manage options type, and default values.
+ */
 interface StorageFactoryInterface
 {
     /**

--- a/StorageFactory/StorageFactoryInterface.php
+++ b/StorageFactory/StorageFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Prometheus\Storage\Adapter;
+
+interface StorageFactoryInterface
+{
+    /**
+     * Gets the name of the adapter managed by this factory.
+     */
+    public function getName(): string;
+
+    /**
+     * Creates the adapter instance.
+     */
+    public function create(array $options): Adapter;
+}

--- a/Tests/BundleEnvRedisTest.php
+++ b/Tests/BundleEnvRedisTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle;
+
+use Prometheus\Storage\Redis;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\AppKernel;
+
+/**
+ * @group functional
+ */
+class BundleEnvRedisTest extends WebTestCase
+{
+    public function testBundle(): void
+    {
+        $_ENV['TESTS_REDIS_URL'] = 'redis://127.0.0.1:6379?timeout=0.1&read_timeout=10&persistent_connections=false';
+
+        $client = self::createClient(['test_case' => 'PrometheusMetricsBundle', 'root_config' => 'env_config_redis.yml']);
+        $client->request('GET', '/metrics/prometheus');
+
+        self::assertStringContainsString('myapp_instance_name{instance="dev"} 1', $client->getResponse()->getContent());
+        self::assertInstanceOf(Redis::class, self::getContainer()->get('prometheus_metrics_bundle.adapter'));
+    }
+
+    protected static function getKernelClass(): string
+    {
+        require_once __DIR__.'/Fixtures/App/AppKernel.php';
+
+        return AppKernel::class;
+    }
+
+    protected static function createKernel(array $options = []): KernelInterface
+    {
+        $class = self::getKernelClass();
+
+        if (!isset($options['test_case'])) {
+            throw new \InvalidArgumentException('The option "test_case" must be set.');
+        }
+
+        return new $class(
+            self::getVarDir(),
+            $options['test_case'],
+            $options['root_config'] ?? 'config.yml',
+            $options['environment'] ?? strtolower(static::getVarDir().$options['test_case']),
+            $options['debug'] ?? true
+        );
+    }
+
+    private static function getVarDir(): string
+    {
+        return 'FB'.substr(strrchr(static::class, '\\'), 1);
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -22,6 +22,7 @@ class ConfigurationTest extends TestCase
                 [
                     'namespace' => 'myapp',
                     'type' => 'in_memory',
+                    'storage' => ['type' => 'in_memory'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_metrics' => false,
                     'disable_default_promphp_metrics' => false,
@@ -48,18 +49,19 @@ class ConfigurationTest extends TestCase
                 [
                     'namespace' => 'myapp',
                     'type' => 'redis',
-                    'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'redis' => [
                         'host' => '127.0.0.1',
                         'port' => 6379,
                         'timeout' => 0.1,
-                        'read_timeout' => 10,
+                        'read_timeout' => '10',
                         'persistent_connections' => false,
                         'password' => null,
                     ],
                     'disable_default_metrics' => false,
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
+                    'storage' => ['type' => 'redis'],
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
                 ],
             ],
             [
@@ -81,18 +83,73 @@ class ConfigurationTest extends TestCase
                 [
                     'namespace' => 'myapp',
                     'type' => 'redis',
-                    'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'redis' => [
                         'host' => '/var/run/redis/redis.sock',
-                        'port' => 6379,
                         'timeout' => 0.1,
                         'read_timeout' => '10',
                         'persistent_connections' => false,
                         'password' => null,
+                        'port' => 6379,
                     ],
                     'disable_default_metrics' => false,
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
+                    'storage' => ['type' => 'redis'],
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                ],
+            ],
+            [
+                'redis storage dsn',
+                [
+                    'namespace' => 'myapp',
+                    'storage' => 'redis://127.0.0.1:6379?timeout=0.1&read_timeout=10&persistent_connections=false',
+                    'disable_default_metrics' => false,
+                    'enable_console_metrics' => false,
+                ],
+                [
+                    'namespace' => 'myapp',
+                    'storage' => [
+                        'url' => 'redis://127.0.0.1:6379?timeout=0.1&read_timeout=10&persistent_connections=false',
+                    ],
+                    'disable_default_metrics' => false,
+                    'enable_console_metrics' => false,
+                    'type' => 'in_memory',
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                    'disable_default_promphp_metrics' => false,
+                ],
+            ],
+            [
+                'redis storage',
+                [
+                    'namespace' => 'myapp',
+                    'storage' => [
+                        'type' => 'redis',
+                        'host' => '127.0.0.1',
+                        'port' => 6379,
+                        'timeout' => 0.1,
+                        'read_timeout' => 10,
+                        'persistent_connections' => false,
+                        'password' => null,
+                    ],
+                    'disable_default_metrics' => false,
+                    'enable_console_metrics' => false,
+                ],
+                [
+                    'namespace' => 'myapp',
+                    'storage' => [
+                        'type' => 'redis',
+                        'host' => '127.0.0.1',
+                        'port' => 6379,
+                        'timeout' => 0.1,
+                        'read_timeout' => 10,
+                        'persistent_connections' => false,
+                        'password' => null,
+                    ],
+                    'disable_default_metrics' => false,
+                    'enable_console_metrics' => false,
+                    'type' => 'in_memory',
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                    'disable_default_promphp_metrics' => false,
                 ],
             ],
         ];
@@ -118,10 +175,10 @@ class ConfigurationTest extends TestCase
     public function testGetConfigTreeBuilder(string $description, array $config, array $expected)
     {
         $cfg = new Configuration();
-        $treeBuilder = $cfg->getConfigTreeBuilder();
-        $tree = $treeBuilder->buildTree();
-        $result = $tree->finalize($config);
-        self::assertEquals($expected, $result, $description);
+        $tree = $cfg->getConfigTreeBuilder()->buildTree();
+        $result = $tree->finalize($tree->normalize($config));
+
+        self::assertSame($expected, $result, $description);
     }
 
     /**

--- a/Tests/Fixtures/App/PrometheusMetricsBundle/env_config_redis.yml
+++ b/Tests/Fixtures/App/PrometheusMetricsBundle/env_config_redis.yml
@@ -1,0 +1,16 @@
+framework:
+    secret:        test
+    router:        { resource: "%kernel.project_dir%/%kernel.test_case%/routing.yml" }
+    test: true
+    default_locale: en
+    session:
+        storage_factory_id: session.storage.factory.mock_file
+
+services:
+    logger: { class: Psr\Log\NullLogger }
+
+artprima_prometheus_metrics:
+    namespace: myapp
+    storage: "%env(TESTS_REDIS_URL)%"
+    # this will remove "prometheus_bundle_prometheus" from the ignored routes
+    ignored_routes: []

--- a/Tests/Fixtures/App/Storage/Dummy.php
+++ b/Tests/Fixtures/App/Storage/Dummy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\Storage;
+
+use Prometheus\Storage\Adapter;
+
+class Dummy implements Adapter
+{
+    public $options;
+
+    public function __construct(array $options)
+    {
+        $this->options = $options;
+    }
+
+    public function collect(): array
+    {
+        return [];
+    }
+
+    public function updateSummary(array $data): void
+    {
+    }
+
+    public function updateHistogram(array $data): void
+    {
+    }
+
+    public function updateGauge(array $data): void
+    {
+    }
+
+    public function updateCounter(array $data): void
+    {
+    }
+
+    public function wipeStorage(): void
+    {
+    }
+}

--- a/Tests/Fixtures/App/Storage/DummyFactory.php
+++ b/Tests/Fixtures/App/Storage/DummyFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\Storage;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\StorageFactoryInterface;
+use Prometheus\Storage\Adapter;
+
+class DummyFactory implements StorageFactoryInterface
+{
+    public function getName(): string
+    {
+        return 'dummy';
+    }
+
+    public function create(array $options): Adapter
+    {
+        return new Dummy($options);
+    }
+}

--- a/Tests/StorageFactory/ApcFactoryTest.php
+++ b/Tests/StorageFactory/ApcFactoryTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\ApcFactory;
+use PHPUnit\Framework\TestCase;
+
+class ApcFactoryTest extends TestCase
+{
+    public function testFactoryName(): void
+    {
+        $factory = new ApcFactory();
+
+        self::assertSame('apcu', $factory->getName());
+    }
+}

--- a/Tests/StorageFactory/FactoryRegistryTest.php
+++ b/Tests/StorageFactory/FactoryRegistryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\FactoryRegistry;
+use Artprima\PrometheusMetricsBundle\StorageFactory\InMemoryFactory;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\InMemory;
+use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\Storage\Dummy;
+use Tests\Artprima\PrometheusMetricsBundle\Fixtures\App\Storage\DummyFactory;
+
+class FactoryRegistryTest extends TestCase
+{
+    public function testCreateFromEmptyValues(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $factory = new FactoryRegistry();
+        $factory->create([]);
+    }
+
+    public function testCreateWithWrongInvalidType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $factory = new FactoryRegistry([new InMemoryFactory()]);
+        $factory->create(['url' => 'redis']);
+    }
+
+    public function testCreate(): void
+    {
+        $factory = new FactoryRegistry([new InMemoryFactory()]);
+
+        self::assertInstanceOf(InMemory::class, $factory->create(['url' => 'in_memory']));
+    }
+
+    public function testCreateWithOption(): void
+    {
+        $factory = new FactoryRegistry([new DummyFactory()]);
+        $adapter = $factory->create([
+            'url' => 'dummy://localhost:9999/test/?foo1=bar1',
+            'foo2' => 'bar2',
+        ]);
+
+        self::assertInstanceOf(Dummy::class, $adapter);
+        self::assertSame('localhost', $adapter->options['host']);
+        self::assertSame(9999, $adapter->options['port']);
+        self::assertSame('test', $adapter->options['path']);
+        self::assertSame('bar1', $adapter->options['foo1']);
+        self::assertSame('bar2', $adapter->options['foo2']);
+    }
+}

--- a/Tests/StorageFactory/FactoryRegistryTest.php
+++ b/Tests/StorageFactory/FactoryRegistryTest.php
@@ -51,4 +51,12 @@ class FactoryRegistryTest extends TestCase
         self::assertSame('bar1', $adapter->options['foo1']);
         self::assertSame('bar2', $adapter->options['foo2']);
     }
+
+    public function testCreateWithWrongDsn(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $factory = new FactoryRegistry();
+        $factory->create(['url' => 'http:///']);
+    }
 }

--- a/Tests/StorageFactory/InMemoryFactoryTest.php
+++ b/Tests/StorageFactory/InMemoryFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\InMemoryFactory;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\InMemory;
+
+class InMemoryFactoryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $factory = new InMemoryFactory();
+
+        self::assertInstanceOf(InMemory::class, $factory->create([]));
+    }
+
+    public function testFactoryName(): void
+    {
+        $factory = new InMemoryFactory();
+
+        self::assertSame('in_memory', $factory->getName());
+    }
+}

--- a/Tests/StorageFactory/RedisFactoryTest.php
+++ b/Tests/StorageFactory/RedisFactoryTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\RedisFactory;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\Redis;
+
+class RedisFactoryTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $factory = new RedisFactory();
+
+        self::assertInstanceOf(Redis::class, $factory->create([]));
+    }
+
+    public function testFullOptions(): void
+    {
+        $factory = new RedisFactory();
+
+        self::assertInstanceOf(Redis::class, $factory->create([
+            'pass' => '',
+            'path' => 1,
+            'timeout' => 0.1,
+            'read_timeout' => '10',
+            'persistent_connections' => false,
+            'prefix' => 'PROMETHEUS_',
+        ]));
+    }
+
+    public function testFactoryName(): void
+    {
+        $factory = new RedisFactory();
+
+        self::assertSame('redis', $factory->getName());
+    }
+}


### PR DESCRIPTION
This PR provides factories for the storage adapter. This allows evaluation of the adapter in runtime.
With this internal update you can now:
 - use env var in configuration file of the bundle
 - declare your own storage adapter
 - use DSN for storage declaration (bonus)

To declare a custom adapter you should add a custom facotry and add the tag `prometheus_metrics_bundle.adapter_factory`. I also register the factory interface for auto configuration.

The storage factory is designed to manage their own options. They should extract from array and cast if necessary their options  and also manage default values before injection. I could change this parameter to a class to simplify the usage options (I don't know if this is relevant).  

I change the configuration to move `type` and `redis` under a new parameter `storage` and I deprecated those parameters. 
I add a variable parameter `storage.options` to allows additionnal parameters. 

The container will have a new parameter for debug `prometheus_metrics_bundle.storage`. The container parameters `prometheus_metrics_bundle.type` and `prometheus_metrics_bundle.redis` are still set for debug purpose but are not use anymore.

I am not sure about the `storage`. It provides all known parameters for redis and apcu but I feel documentation could be enough. This means those parameters will move under `storage.options` as variable parameters.

I also add support of DSN. The value extract from the dsn will override the defined parameters.
Here is a example:

```yaml
artprima_prometheus_metrics:
    # namespace is used to prefix the prometheus metrics
    namespace: myapp

    # type and redis are still available.

    # metrics backend
    storage:
        # DSN of the storage. All parsed values will override explicitly set parameters. Ex: redis://127.0.0.1?timeout=0.1
        url: ~
        
        # Known values: in_memory, apcu, redis
        type: in_memory
        
        # Available parameters used by redis
        host: 127.0.0.1
        port: 6379
        timeout: 0.1
        read_timeout: 10
        persistent_connections: false
        password: ~
        database: ~ # Int value used by redis adapter
        prefix: ~   # String value used by redis and apcu

        # A variable parameter to define additionnal options as key / value.
        options:
            foo: bar
```
