### PR TITLE
Fix wrong tag success in output of 'artprima:prometheus:metrics:clear'

### DIFF
--- a/Command/ClearMetricsCommand.php
+++ b/Command/ClearMetricsCommand.php
@@ -8,6 +8,7 @@ use Prometheus\Storage\Adapter;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * Clear metrics from prometheus storage.
@@ -43,11 +44,12 @@ class ClearMetricsCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln(sprintf('Clearing storage from <comment>%s</comment>', get_class($this->storage)));
+        $io = new SymfonyStyle($input, $output);
+        $io->writeln(sprintf('Clearing storage from <comment>%s</comment>', get_class($this->storage)));
 
         $this->storage->wipeStorage();
 
-        $output->writeln('<success>The storage was successfully cleared.</success>');
+        $io->success('The storage was successfully cleared.');
 
         return 0;
     }

--- a/Tests/Command/ClearMetricsCommandTest.php
+++ b/Tests/Command/ClearMetricsCommandTest.php
@@ -25,12 +25,7 @@ class ClearMetricsCommandTest extends TestCase
         $tester = new CommandTester($application->get('artprima:prometheus:metrics:clear'));
         $tester->execute([]);
 
-        $expected = <<<EOL
-Clearing storage from {$className}
-<success>The storage was successfully cleared.</success>
-
-EOL;
-
-        $this->assertSame($expected, $tester->getDisplay());
+        $this->assertStringContainsString("Clearing storage from $className", $tester->getDisplay());
+        $this->assertStringContainsString("[OK] The storage was successfully cleared.", $tester->getDisplay());
     }
 }

--- a/Tests/Command/ClearMetricsCommandTest.php
+++ b/Tests/Command/ClearMetricsCommandTest.php
@@ -26,6 +26,6 @@ class ClearMetricsCommandTest extends TestCase
         $tester->execute([]);
 
         $this->assertStringContainsString("Clearing storage from $className", $tester->getDisplay());
-        $this->assertStringContainsString("[OK] The storage was successfully cleared.", $tester->getDisplay());
+        $this->assertStringContainsString('[OK] The storage was successfully cleared.', $tester->getDisplay());
     }
 }


### PR DESCRIPTION
This fix a wrong html tag success in the output message.
I use `Symfony\Component\Console\Style\SymfonyStyle` class which it is part of the console component to display output. 