### PR TITLE
Add support of APCng adapter (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 Symfony 5 and 6 Prometheus Metrics Bundle
 =========================================
 
+A Symfony bundle for the `promphp/prometheus_client_php`.
+
 Installation
 ============
 
@@ -79,7 +81,7 @@ artprima_prometheus_metrics:
         # DSN of the storage. All parsed values will override explicitly set parameters. Ex: redis://127.0.0.1?timeout=0.1
         url: ~
         
-        # Known values: in_memory, apcu, redis
+        # Known values: in_memory, apcu, apcng, redis
         type: in_memory
         
         # Available parameters used by redis
@@ -105,6 +107,15 @@ artprima_prometheus_metrics:
     # used to enable console metrics
     enable_console_metrics: false
 ```
+
+Supported types are:
+| Adapter name | Prometheus class            |
+|--------------|-----------------------------|
+| in_memory    | Prometheus\Storage\InMemory |
+| apcu         | Prometheus\Storage\APC      |
+| apcung       | Prometheus\Storage\APCng    |
+| redis        | Prometheus\Storage\Redis    |
+
 
 `routes.yaml`
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -72,5 +72,10 @@
              class="Artprima\PrometheusMetricsBundle\StorageFactory\ApcFactory">
         <tag name="prometheus_metrics_bundle.adapter_factory" />
     </service>
+
+    <service id="Artprima\PrometheusMetricsBundle\StorageFactory\APCngFactory"
+             class="Artprima\PrometheusMetricsBundle\StorageFactory\APCngFactory">
+        <tag name="prometheus_metrics_bundle.adapter_factory" />
+    </service>
 </services>
 </container>

--- a/StorageFactory/APCngFactory.php
+++ b/StorageFactory/APCngFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Prometheus\Storage\APCng;
+
+class APCngFactory implements StorageFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function create(array $options): APCng
+    {
+        return new APCng($options['prefix'] ?? APCng::PROMETHEUS_PREFIX);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName(): string
+    {
+        return 'apcng';
+    }
+}

--- a/Tests/StorageFactory/APCngFactoryTest.php
+++ b/Tests/StorageFactory/APCngFactoryTest.php
@@ -10,13 +10,14 @@ use Prometheus\Storage\APCng;
 
 class APCngFactoryTest extends TestCase
 {
-//    public function testCreate(): void
-//    {
-//        $factory = new APCngFactory();
-//
-//        self::assertInstanceOf(APCng::class, $factory->create([]));
-//    }
+    /**
+    public function testCreate(): void
+    {
+        $factory = new APCngFactory();
 
+        self::assertInstanceOf(APCng::class, $factory->create([]));
+    }
+     */
     public function testFactoryName(): void
     {
         $factory = new APCngFactory();

--- a/Tests/StorageFactory/APCngFactoryTest.php
+++ b/Tests/StorageFactory/APCngFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
+
+use Artprima\PrometheusMetricsBundle\StorageFactory\APCngFactory;
+use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\APCng;
+
+class APCngFactoryTest extends TestCase
+{
+//    public function testCreate(): void
+//    {
+//        $factory = new APCngFactory();
+//
+//        self::assertInstanceOf(APCng::class, $factory->create([]));
+//    }
+
+    public function testFactoryName(): void
+    {
+        $factory = new APCngFactory();
+
+        self::assertSame('apcng', $factory->getName());
+    }
+}

--- a/Tests/StorageFactory/ApcFactoryTest.php
+++ b/Tests/StorageFactory/ApcFactoryTest.php
@@ -10,13 +10,14 @@ use Prometheus\Storage\APC;
 
 class ApcFactoryTest extends TestCase
 {
-//    public function testCreate(): void
-//    {
-//        $factory = new ApcFactory();
-//
-//        self::assertInstanceOf(APC::class, $factory->create([]));
-//    }
+    /**
+    public function testCreate(): void
+    {
+        $factory = new ApcFactory();
 
+        self::assertInstanceOf(APC::class, $factory->create([]));
+    }
+     */
     public function testFactoryName(): void
     {
         $factory = new ApcFactory();

--- a/Tests/StorageFactory/ApcFactoryTest.php
+++ b/Tests/StorageFactory/ApcFactoryTest.php
@@ -6,9 +6,17 @@ namespace Tests\Artprima\PrometheusMetricsBundle\StorageFactory;
 
 use Artprima\PrometheusMetricsBundle\StorageFactory\ApcFactory;
 use PHPUnit\Framework\TestCase;
+use Prometheus\Storage\APC;
 
 class ApcFactoryTest extends TestCase
 {
+//    public function testCreate(): void
+//    {
+//        $factory = new ApcFactory();
+//
+//        self::assertInstanceOf(APC::class, $factory->create([]));
+//    }
+
     public function testFactoryName(): void
     {
         $factory = new ApcFactory();


### PR DESCRIPTION
This PR adds a factory for the APCng adapter.

Beware the 2 factories for apc are not tested. The build does not install apcu extension but I have added and commented missing tests. I prefer to not change the action workflow.