### PR TITLE
Fix supported storage types by adding 'apcng' to allowed values

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('artprima_prometheus_metrics');
         $rootNode = $treeBuilder->getRootNode();
 
-        $supportedTypes = ['in_memory', 'apcu', 'apcung', 'redis'];
+        $supportedTypes = ['in_memory', 'apcu', 'apcng', 'redis'];
 
         $rootNode
             // Manage deprecated parameter "type": will be transform as storage.url

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('artprima_prometheus_metrics');
         $rootNode = $treeBuilder->getRootNode();
 
-        $supportedTypes = ['in_memory', 'apcu', 'apcnug', 'redis'];
+        $supportedTypes = ['in_memory', 'apcu', 'apcung', 'redis'];
 
         $rootNode
             // Manage deprecated parameter "type": will be transform as storage.url

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('artprima_prometheus_metrics');
         $rootNode = $treeBuilder->getRootNode();
 
-        $supportedTypes = ['in_memory', 'apcu', 'redis'];
+        $supportedTypes = ['in_memory', 'apcu', 'apcnug', 'redis'];
 
         $rootNode
             // Manage deprecated parameter "type": will be transform as storage.url

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Supported types are:
 |--------------|-----------------------------|
 | in_memory    | Prometheus\Storage\InMemory |
 | apcu         | Prometheus\Storage\APC      |
-| apcung       | Prometheus\Storage\APCng    |
+| apcng        | Prometheus\Storage\APCng    |
 | redis        | Prometheus\Storage\Redis    |
 
 

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -14,6 +14,38 @@ class ConfigurationTest extends TestCase
     {
         return [
             [
+                'apcu',
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'apcu',
+                ],
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'apcu',
+                    'storage' => ['type' => 'apcu'],
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                    'disable_default_metrics' => false,
+                    'disable_default_promphp_metrics' => false,
+                    'enable_console_metrics' => false,
+                ],
+            ],
+            [
+                'apcung',
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'apcung',
+                ],
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'apcung',
+                    'storage' => ['type' => 'apcung'],
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                    'disable_default_metrics' => false,
+                    'disable_default_promphp_metrics' => false,
+                    'enable_console_metrics' => false,
+                ],
+            ],
+            [
                 'in_memory',
                 [
                     'namespace' => 'myapp',

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,15 +30,15 @@ class ConfigurationTest extends TestCase
                 ],
             ],
             [
-                'apcung',
+                'apcng',
                 [
                     'namespace' => 'myapp',
-                    'type' => 'apcung',
+                    'type' => 'apcng',
                 ],
                 [
                     'namespace' => 'myapp',
-                    'type' => 'apcung',
-                    'storage' => ['type' => 'apcung'],
+                    'type' => 'apcng',
+                    'storage' => ['type' => 'apcng'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_metrics' => false,
                     'disable_default_promphp_metrics' => false,


### PR DESCRIPTION
bug of https://github.com/artprima/prometheus-metrics-bundle/commit/150b9c71ccd5ee7303444a69fd06c86a5c516064