### PR TITLE
Lazy load command description

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -49,7 +49,7 @@
     <!-- Register commands -->
     <service id="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand" class="Artprima\PrometheusMetricsBundle\Command\ClearMetricsCommand">
         <argument type="service" id="prometheus_metrics_bundle.adapter"/>
-        <tag name="console.command"  command="artprima:prometheus:metrics:clear"/>
+        <tag name="console.command" command="artprima:prometheus:metrics:clear" description="Clear all collected metrics from storage"/>
     </service>
 
     <!-- Register storage fatories -->


### PR DESCRIPTION
This only initializes the command when it is executed. When listing commands, problems occur if APCu is not enabled in the CLI SAPI (when using `apcu` or `apcng` storage). This problem (`APCu is not enabled`) is now postponed until the command is executed.

This feature came with [Symfony 5.3](https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description), so it should work within the version constraints.