### PR TITLE
Add some compatibilities with sf6.3 and phpunit 10 (#88)

### DIFF
--- a/ArtprimaPrometheusMetricsBundle.php
+++ b/ArtprimaPrometheusMetricsBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ArtprimaPrometheusMetricsBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/Command/ClearMetricsCommand.php
+++ b/Command/ClearMetricsCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\Command;
 
 use Prometheus\Storage\Adapter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -13,6 +14,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Clear metrics from prometheus storage.
  */
+#[AsCommand('artprima:prometheus:metrics:clear', 'Clear all collected metrics from storage.')]
 class ClearMetricsCommand extends Command
 {
     /**
@@ -27,11 +29,11 @@ class ClearMetricsCommand extends Command
         $this->storage = $storage;
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('artprima:prometheus:metrics:clear')
-            ->setDescription('Clear all collected metrics from storage')
+            ->setDescription('Clear all collected metrics from storage.')
         ;
     }
 

--- a/Controller/MetricsController.php
+++ b/Controller/MetricsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\Controller;
 
 use Artprima\PrometheusMetricsBundle\Metrics\Renderer;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Class MetricsController.
@@ -18,7 +19,7 @@ class MetricsController
         $this->renderer = $metricsRenderer;
     }
 
-    public function prometheus()
+    public function prometheus(): Response
     {
         return $this->renderer->renderResponse();
     }

--- a/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
+++ b/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  */
 class ArtprimaPrometheusMetricsExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
@@ -62,7 +62,7 @@ class ArtprimaPrometheusMetricsExtension extends Extension
     /**
      * Set the parameters for the factory of adapter.
      */
-    private function prepareAdapterParameters(array $config, ContainerBuilder $container)
+    private function prepareAdapterParameters(array $config, ContainerBuilder $container): void
     {
         $factoryParameters = $config['storage'];
 

--- a/DependencyInjection/Compiler/RegisterMetricsCollectorPass.php
+++ b/DependencyInjection/Compiler/RegisterMetricsCollectorPass.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class RegisterMetricsCollectorPass implements CompilerPassInterface
 {
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (false === $container->hasDefinition(MetricsCollectorRegistry::class)) {
             return;

--- a/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
+++ b/DependencyInjection/Compiler/ResolveAdapterDefinitionPass.php
@@ -19,7 +19,7 @@ class ResolveAdapterDefinitionPass implements CompilerPassInterface
 
     public const TAG_NAME = 'prometheus_metrics_bundle.adapter_factory';
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition(FactoryRegistry::class)) {
             return;

--- a/EventListener/MetricsCollectorListener.php
+++ b/EventListener/MetricsCollectorListener.php
@@ -168,7 +168,7 @@ class MetricsCollectorListener implements LoggerAwareInterface
         }
     }
 
-    public function onConsoleCommand(ConsoleCommandEvent $event)
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
     {
         foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
             if (!self::isSupportedEvent($collector, 'collectConsoleCommand', ConsoleCommandMetricsCollectorInterface::class)) {
@@ -188,7 +188,7 @@ class MetricsCollectorListener implements LoggerAwareInterface
         }
     }
 
-    public function onConsoleTerminate(ConsoleTerminateEvent $event)
+    public function onConsoleTerminate(ConsoleTerminateEvent $event): void
     {
         foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
             if (!self::isSupportedEvent($collector, 'collectConsoleTerminate', ConsoleTerminateMetricsCollectorInterface::class)) {
@@ -208,7 +208,7 @@ class MetricsCollectorListener implements LoggerAwareInterface
         }
     }
 
-    public function onConsoleError(ConsoleErrorEvent $event)
+    public function onConsoleError(ConsoleErrorEvent $event): void
     {
         foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
             if (!self::isSupportedEvent($collector, 'collectConsoleError', ConsoleErrorMetricsCollectorInterface::class)) {

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class ConfigurationTest extends TestCase
 {
-    public function configDataProvider(): array
+    public static function configDataProvider(): array
     {
         return [
             [
@@ -187,7 +187,7 @@ class ConfigurationTest extends TestCase
         ];
     }
 
-    public function invalidConfigDataProvider(): array
+    public static function invalidConfigDataProvider(): array
     {
         return [
             [

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -72,7 +72,7 @@ class AppMetricsTest extends TestCase
         );
     }
 
-    public function provideMetricsName(): array
+    public static function provideMetricsName(): array
     {
         return [
             [200, 'http_2xx_responses_total'],


### PR DESCRIPTION
Fix some compatibilities:
- Add missing return type on method
- Add Attribute on console command
- Add static method on data provider for phpunit

This should remove some deprecated message listed by the component of symfony (fixes #88)