### PR TITLE
Enhancement: Bumps minimum Symfony versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,15 +14,15 @@
     "php": "^8.1",
     "ext-json": "*",
     "promphp/prometheus_client_php": "^2.6",
-    "symfony/http-kernel": "^5.4|^6.4|^7.0",
-    "symfony/dependency-injection": "^5.4|^6.4|^7.0",
-    "symfony/config": "^5.4|^6.4|^7.0"
+    "symfony/http-kernel": "^5.4|^6.4|^7.2",
+    "symfony/dependency-injection": "^5.4|^6.4|^7.2",
+    "symfony/config": "^5.4|^6.4|^7.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0|^10.0",
-    "symfony/yaml": "^5.4|^6.2|^7.0",
-    "symfony/browser-kit": "^5.4|^6.4|^7.0",
-    "symfony/framework-bundle": "^5.4|^6.4|^7.0",
+    "symfony/yaml": "^5.4|^6.4|^7.2",
+    "symfony/browser-kit": "^5.4|^6.4|^7.2",
+    "symfony/framework-bundle": "^5.4|^6.4|^7.2",
     "friendsofphp/php-cs-fixer": "^3.17",
     "escapestudios/symfony2-coding-standard": "^3.11",
     "squizlabs/php_codesniffer": "^3.5"


### PR DESCRIPTION
Only support [Symfony versions](https://symfony.com/releases) (especially non-LTS versions) that are still supported.

Follows #108

----

```bash
symfony composer require symfony/http-kernel:"^5.4|^6.4|^7.2" symfony/dependency-injection:"^5.4|^6.4|^7.2" symfony/config:"^5.4|^6.4|^7.2"
symfony composer require --dev symfony/yaml:"^5.4|^6.4|^7.2" symfony/browser-kit:"^5.4|^6.4|^7.2" symfony/framework-bundle:"^5.4|^6.4|^7.2"
```