### PR TITLE
Enhancement: Bumps `phpunit/phpunit` minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "symfony/config": "^5.4|^6.4|^7.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0|^10.0",
+    "phpunit/phpunit": "^10.0",
     "symfony/yaml": "^5.4|^6.4|^7.2",
     "symfony/browser-kit": "^5.4|^6.4|^7.2",
     "symfony/framework-bundle": "^5.4|^6.4|^7.2",


### PR DESCRIPTION
As long as this bundle still supports php v8.1, we should not upgrade phpunit any further. But at least drop PHPUnit v9.

https://phpunit.de/supported-versions.html 

```bash
symfony composer require --dev phpunit/phpunit:^10.0 -w
```