### PR TITLE
Enhancement: Configurable buckets

### DIFF
--- a/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
+++ b/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
@@ -55,6 +55,7 @@ class ArtprimaPrometheusMetricsExtension extends Extension
         $container->setParameter('prometheus_metrics_bundle.disable_default_metrics', $config['disable_default_metrics']);
         $container->setParameter('prometheus_metrics_bundle.enable_default_promphp_metrics', !$config['disable_default_promphp_metrics']);
         $container->setParameter('prometheus_metrics_bundle.enable_console_metrics', $config['enable_console_metrics']);
+        $container->setParameter('prometheus_metrics_bundle.buckets', $config['buckets']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
+use Prometheus\Histogram;
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -153,6 +154,11 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->defaultValue([])
+                ->end()
+                ->arrayNode('buckets')
+                    ->prototype('float')->end()
+                    ->defaultValue(Histogram::getDefaultBuckets())
+                    ->cannotBeEmpty()
                 ->end()
             ->end();
 

--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -23,7 +23,10 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
 
     private float $startedAt = 0;
 
-    public function __construct(private readonly LabelResolver $labelResolver, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
+    /**
+     * @param array<float> $buckets
+     */
+    public function __construct(private readonly LabelResolver $labelResolver, private readonly array $buckets, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
     {
     }
 
@@ -143,7 +146,8 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
             $this->namespace,
             'request_durations_histogram_seconds',
             'request durations in seconds',
-            $this->getLabelNames()
+            $this->getLabelNames(),
+            $this->buckets,
         );
 
         $histogram->observe($duration, $this->getAllLabelValues());

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ artprima_prometheus_metrics:
           type: "request_header" # Create a subscriber and set up the `X-Client-Name` header in the request. See example below.
           value: "X-Client-Name"
 
+    # Custom buckets in metrics histogram.
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+
     # metrics backend
     storage:
         # DSN of the storage. All parsed values will override explicitly set parameters. Ex: redis://127.0.0.1?timeout=0.1

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -36,6 +36,7 @@
 
     <service id="Artprima\PrometheusMetricsBundle\Metrics\AppMetrics" class="Artprima\PrometheusMetricsBundle\Metrics\AppMetrics" public="false" autowire="false" autoconfigure="false">
         <argument type="service" id="Artprima\PrometheusMetricsBundle\Metrics\LabelResolver" />
+        <argument>%prometheus_metrics_bundle.buckets%</argument>
         <tag name="prometheus_metrics_bundle.metrics_collector" />
         <tag name="prometheus_metrics_bundle.default_metrics" />
     </service>

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -28,6 +28,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -45,6 +46,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -62,6 +64,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -98,6 +101,7 @@ class ConfigurationTest extends TestCase
                     'storage' => ['type' => 'redis'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -133,6 +137,7 @@ class ConfigurationTest extends TestCase
                     'storage' => ['type' => 'redis'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -154,6 +159,7 @@ class ConfigurationTest extends TestCase
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_promphp_metrics' => false,
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
             [
@@ -189,6 +195,7 @@ class ConfigurationTest extends TestCase
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_promphp_metrics' => false,
                     'labels' => [],
+                    'buckets' => [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0],
                 ],
             ],
         ];

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -36,7 +36,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequest(): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -55,7 +55,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequestOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -90,7 +90,7 @@ class AppMetricsTest extends TestCase
      */
     public function testCollectResponse(int $code, string $metricsName): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -113,7 +113,7 @@ class AppMetricsTest extends TestCase
     {
         self::registerMicrotimeMock('Artprima\PrometheusMetricsBundle\Metrics');
 
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10]);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -155,7 +155,7 @@ class AppMetricsTest extends TestCase
 
     public function testUseMetricInfoResolver(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics($this->labelResolver, [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10], new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);
@@ -185,7 +185,7 @@ class AppMetricsTest extends TestCase
             new LabelConfig('client_name', LabelConfig::REQUEST_HEADER, 'X-Client-Name'),
         ];
 
-        $metrics = new AppMetrics(new LabelResolver($labels), new DummyMetricInfoResolver());
+        $metrics = new AppMetrics(new LabelResolver($labels), [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10], new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);

--- a/Tests/Metrics/RendererTest.php
+++ b/Tests/Metrics/RendererTest.php
@@ -30,7 +30,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver());
+        $metrics = new AppMetrics(new LabelResolver(), [1]);
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->render();
@@ -46,7 +46,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver());
+        $metrics = new AppMetrics(new LabelResolver(), [1]);
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->renderResponse();


### PR DESCRIPTION
Adds configurable buckets for `AppMetric` histograms to project:

```yaml
artprima_prometheus_metrics:
    # example buckets
    buckets: [0.05, 0.1, 0.25, 0.5, 1, 5, 10, 30]
```

@denisvmedia @Johnmeurt I recreated my changes after merging #121. This time it's possible to use `Histogram:getDefaultBuckets()` as a single source of truth.

- Supersedes #116
- Follows #121
