### PR TITLE
fix: Add back the routing.xml file (#132)

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Deprecated: should be removed in 1.22 -->
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="prometheus_bundle_prometheus" controller="Artprima\PrometheusMetricsBundle\Controller\MetricsController::prometheus" path="/metrics/prometheus">
+    </route>
+</routes>


### PR DESCRIPTION
Add the old `routing.xml` file to prevent first install of 1.21 to fail during execution of cache clear command.