### PR TITLE
Enhancement: Configurable buckets (supersedes #122)

### DIFF
--- a/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
+++ b/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
 use Artprima\PrometheusMetricsBundle\DependencyInjection\Compiler\ResolveAdapterDefinitionPass;
-use Artprima\PrometheusMetricsBundle\Metrics\AppMetrics;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelConfig;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelResolver;
 use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorInterface;
@@ -60,8 +59,6 @@ class ArtprimaPrometheusMetricsExtension extends Extension
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
-        $container->getDefinition(AppMetrics::class)
-            ->setArgument(1, '%prometheus_metrics_bundle.buckets%');
 
         if (isset($config['labels'])) {
             $labelConfigServices = [];

--- a/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
+++ b/DependencyInjection/ArtprimaPrometheusMetricsExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
 use Artprima\PrometheusMetricsBundle\DependencyInjection\Compiler\ResolveAdapterDefinitionPass;
+use Artprima\PrometheusMetricsBundle\Metrics\AppMetrics;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelConfig;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelResolver;
 use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorInterface;
@@ -55,9 +56,12 @@ class ArtprimaPrometheusMetricsExtension extends Extension
         $container->setParameter('prometheus_metrics_bundle.disable_default_metrics', $config['disable_default_metrics']);
         $container->setParameter('prometheus_metrics_bundle.enable_default_promphp_metrics', !$config['disable_default_promphp_metrics']);
         $container->setParameter('prometheus_metrics_bundle.enable_console_metrics', $config['enable_console_metrics']);
+        $container->setParameter('prometheus_metrics_bundle.buckets', $config['buckets']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yaml');
+        $container->getDefinition(AppMetrics::class)
+            ->setArgument(1, '%prometheus_metrics_bundle.buckets%');
 
         if (isset($config['labels'])) {
             $labelConfigServices = [];

--- a/DependencyInjection/Compiler/MetricInfoResolverCompilerPass.php
+++ b/DependencyInjection/Compiler/MetricInfoResolverCompilerPass.php
@@ -32,7 +32,7 @@ class MetricInfoResolverCompilerPass implements CompilerPassInterface
         }
 
         foreach ($taggedServices as $id => $tags) {
-            $definition->addArgument(new Reference($id));
+            $definition->setArgument('$metricInfoResolver', new Reference($id));
         }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
 use Prometheus\Histogram;
-
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Artprima\PrometheusMetricsBundle\DependencyInjection;
 
+use Prometheus\Histogram;
+
 use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -153,6 +155,11 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->defaultValue([])
+                ->end()
+                ->arrayNode('buckets')
+                    ->prototype('float')->end()
+                    ->defaultValue(Histogram::getDefaultBuckets())
+                    ->cannotBeEmpty()
                 ->end()
             ->end();
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -159,6 +159,26 @@ class Configuration implements ConfigurationInterface
                     ->prototype('float')->end()
                     ->defaultValue(Histogram::getDefaultBuckets())
                     ->cannotBeEmpty()
+                    ->validate()
+                        ->ifTrue(static function (array $buckets): bool {
+                            $previousBucket = null;
+
+                            foreach ($buckets as $bucket) {
+                                if ($bucket < 0) {
+                                    return true;
+                                }
+
+                                if (null !== $previousBucket && $bucket <= $previousBucket) {
+                                    return true;
+                                }
+
+                                $previousBucket = $bucket;
+                            }
+
+                            return false;
+                        })
+                        ->thenInvalid('Buckets must be unique, sorted in strictly increasing order, and greater than or equal to 0.')
+                    ->end()
                 ->end()
             ->end();
 

--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -31,7 +31,7 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
     /**
      * @param array<float>|null $buckets
      */
-    public function __construct(private readonly LabelResolver $labelResolver, ?array $buckets = null, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
+    public function __construct(private readonly LabelResolver $labelResolver, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null, ?array $buckets = null)
     {
         $this->buckets = $buckets ?? Histogram::getDefaultBuckets();
     }

--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -23,7 +23,10 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
 
     private float $startedAt = 0;
 
-    public function __construct(private readonly LabelResolver $labelResolver, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
+    /**
+     * @param array<float> $buckets
+     */
+    public function __construct(private readonly LabelResolver $labelResolver, private readonly array $buckets, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
     {
     }
 
@@ -147,7 +150,8 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
             $this->namespace,
             'request_durations_histogram_seconds',
             'request durations in seconds',
-            $this->getLabelNames()
+            $this->getLabelNames(),
+            $this->buckets
         );
 
         $histogram->observe($duration, $this->getAllLabelValues());

--- a/Metrics/AppMetrics.php
+++ b/Metrics/AppMetrics.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Artprima\PrometheusMetricsBundle\Metrics;
 
 use Prometheus\Exception\MetricNotFoundException;
+use Prometheus\Histogram;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
@@ -22,12 +23,17 @@ class AppMetrics implements PreRequestMetricsCollectorInterface, RequestMetricsC
     use MetricsCollectorInitTrait;
 
     private float $startedAt = 0;
+    /**
+     * @var array<float>
+     */
+    private readonly array $buckets;
 
     /**
-     * @param array<float> $buckets
+     * @param array<float>|null $buckets
      */
-    public function __construct(private readonly LabelResolver $labelResolver, private readonly array $buckets, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
+    public function __construct(private readonly LabelResolver $labelResolver, ?array $buckets = null, private readonly ?MetricInfoResolverInterface $metricInfoResolver = null)
     {
+        $this->buckets = $buckets ?? Histogram::getDefaultBuckets();
     }
 
     public function collectRequest(RequestEvent $event): void

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ artprima_prometheus_metrics:
           type: "request_header" # Create a subscriber and set up the `X-Client-Name` header in the request. See example below.
           value: "X-Client-Name"
 
+    # Custom buckets in metrics histogram.
+    buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+
     # metrics backend
     storage:
         # DSN of the storage. All parsed values will override explicitly set parameters. Ex: redis://127.0.0.1?timeout=0.1

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ artprima_prometheus_metrics:
           type: "request_header" # Create a subscriber and set up the `X-Client-Name` header in the request. See example below.
           value: "X-Client-Name"
 
-    # Custom buckets in metrics histogram.
+    # Custom buckets for the request duration histogram.
     buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
 
     # metrics backend

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ artprima_prometheus_metrics:
           value: "X-Client-Name"
 
     # Custom buckets for the request duration histogram.
-    buckets: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0]
+    # Buckets must be unique and strictly increasing. Omit this option to use the Prometheus client defaults.
+    buckets: [0.1, 0.3, 1.0, 3.0]
 
     # metrics backend
     storage:

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -35,7 +35,8 @@ services:
 
   Artprima\PrometheusMetricsBundle\Metrics\AppMetrics:
     arguments:
-      - '@Artprima\PrometheusMetricsBundle\Metrics\LabelResolver'
+      $labelResolver: '@Artprima\PrometheusMetricsBundle\Metrics\LabelResolver'
+      $buckets: '%prometheus_metrics_bundle.buckets%'
     tags:
       - { name: prometheus_metrics_bundle.metrics_collector }
       - { name: prometheus_metrics_bundle.default_metrics }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -81,13 +81,13 @@ class ConfigurationTest extends TestCase
                 [
                     'namespace' => 'myapp',
                     'type' => 'in_memory',
+                    'buckets' => $customBuckets,
                     'storage' => ['type' => 'in_memory'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_metrics' => false,
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
-                    'buckets' => $customBuckets,
                 ],
             ],
             [
@@ -285,6 +285,33 @@ class ConfigurationTest extends TestCase
                     ],
                 ],
                 'Invalid configuration for path "artprima_prometheus_metrics.storage.prefix": Invalid prefix. Make sure it matches the following regex: ^[a-zA-Z_:][a-zA-Z0-9_:]*$',
+            ],
+            [
+                'Duplicate buckets',
+                [
+                    'type' => 'in_memory',
+                    'namespace' => 'myapp',
+                    'buckets' => [0.1, 0.1],
+                ],
+                'Invalid configuration for path "artprima_prometheus_metrics.buckets": Buckets must be unique, sorted in strictly increasing order, and greater than or equal to 0.',
+            ],
+            [
+                'Unsorted buckets',
+                [
+                    'type' => 'in_memory',
+                    'namespace' => 'myapp',
+                    'buckets' => [0.5, 0.1],
+                ],
+                'Invalid configuration for path "artprima_prometheus_metrics.buckets": Buckets must be unique, sorted in strictly increasing order, and greater than or equal to 0.',
+            ],
+            [
+                'Negative buckets',
+                [
+                    'type' => 'in_memory',
+                    'namespace' => 'myapp',
+                    'buckets' => [-0.1, 0.5],
+                ],
+                'Invalid configuration for path "artprima_prometheus_metrics.buckets": Buckets must be unique, sorted in strictly increasing order, and greater than or equal to 0.',
             ],
         ];
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -14,6 +14,7 @@ class ConfigurationTest extends TestCase
     public static function configDataProvider(): array
     {
         $defaultBuckets = Histogram::getDefaultBuckets();
+        $customBuckets = [0.2, 0.6];
 
         return [
             [
@@ -68,6 +69,25 @@ class ConfigurationTest extends TestCase
                     'enable_console_metrics' => false,
                     'labels' => [],
                     'buckets' => $defaultBuckets,
+                ],
+            ],
+            [
+                'in_memory with explicit buckets',
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'in_memory',
+                    'buckets' => $customBuckets,
+                ],
+                [
+                    'namespace' => 'myapp',
+                    'type' => 'in_memory',
+                    'storage' => ['type' => 'in_memory'],
+                    'ignored_routes' => ['prometheus_bundle_prometheus'],
+                    'disable_default_metrics' => false,
+                    'disable_default_promphp_metrics' => false,
+                    'enable_console_metrics' => false,
+                    'labels' => [],
+                    'buckets' => $customBuckets,
                 ],
             ],
             [

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -6,12 +6,15 @@ namespace Tests\Artprima\PrometheusMetricsBundle\DependencyInjection;
 
 use Artprima\PrometheusMetricsBundle\DependencyInjection\Configuration;
 use PHPUnit\Framework\TestCase;
+use Prometheus\Histogram;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class ConfigurationTest extends TestCase
 {
     public static function configDataProvider(): array
     {
+        $defaultBuckets = Histogram::getDefaultBuckets();
+
         return [
             [
                 'apcu',
@@ -28,6 +31,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -45,6 +49,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -62,6 +67,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -98,6 +104,7 @@ class ConfigurationTest extends TestCase
                     'storage' => ['type' => 'redis'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -133,6 +140,7 @@ class ConfigurationTest extends TestCase
                     'storage' => ['type' => 'redis'],
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -154,6 +162,7 @@ class ConfigurationTest extends TestCase
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_promphp_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -189,6 +198,7 @@ class ConfigurationTest extends TestCase
                     'ignored_routes' => ['prometheus_bundle_prometheus'],
                     'disable_default_promphp_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -212,6 +222,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
             [
@@ -235,6 +246,7 @@ class ConfigurationTest extends TestCase
                     'disable_default_promphp_metrics' => false,
                     'enable_console_metrics' => false,
                     'labels' => [],
+                    'buckets' => $defaultBuckets,
                 ],
             ],
         ];

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class AppMetricsTest extends TestCase
 {
+    private const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
     private $namespace;
     private $collectionRegistry;
     /**
@@ -38,7 +39,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequest(): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -57,7 +58,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequestOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -79,7 +80,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectResponseOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -115,7 +116,7 @@ class AppMetricsTest extends TestCase
      */
     public function testCollectResponse(int $code, string $metricsName): void
     {
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -137,8 +138,7 @@ class AppMetricsTest extends TestCase
     public function testSetRequestDuration(): void
     {
         self::registerMicrotimeMock('Artprima\PrometheusMetricsBundle\Metrics');
-
-        $metrics = new AppMetrics($this->labelResolver);
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -180,7 +180,7 @@ class AppMetricsTest extends TestCase
 
     public function testUseMetricInfoResolver(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS, new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);
@@ -210,7 +210,7 @@ class AppMetricsTest extends TestCase
             new LabelConfig('client_name', LabelConfig::REQUEST_HEADER, 'X-Client-Name'),
         ];
 
-        $metrics = new AppMetrics(new LabelResolver($labels), new DummyMetricInfoResolver());
+        $metrics = new AppMetrics(new LabelResolver($labels), self::DEFAULT_BUCKETS, new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -10,6 +10,7 @@ use Artprima\PrometheusMetricsBundle\Metrics\LabelResolver;
 use Artprima\PrometheusMetricsBundle\Metrics\Renderer;
 use PHPUnit\Framework\TestCase;
 use Prometheus\CollectorRegistry;
+use Prometheus\Histogram;
 use Prometheus\Storage\InMemory;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -19,13 +20,13 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class AppMetricsTest extends TestCase
 {
-    private const DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10];
     private $namespace;
     private $collectionRegistry;
     /**
      * @var RendererTest
      */
     private $renderer;
+    private array $defaultBuckets;
 
     private LabelResolver $labelResolver;
 
@@ -34,12 +35,13 @@ class AppMetricsTest extends TestCase
         $this->namespace = 'dummy';
         $this->collectionRegistry = new CollectorRegistry(new InMemory());
         $this->renderer = new Renderer($this->collectionRegistry);
+        $this->defaultBuckets = Histogram::getDefaultBuckets();
         $this->labelResolver = new LabelResolver([]);
     }
 
     public function testCollectRequest(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -58,7 +60,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequestOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -80,7 +82,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectResponseOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -116,7 +118,7 @@ class AppMetricsTest extends TestCase
      */
     public function testCollectResponse(int $code, string $metricsName): void
     {
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -138,7 +140,7 @@ class AppMetricsTest extends TestCase
     public function testSetRequestDuration(): void
     {
         self::registerMicrotimeMock('Artprima\PrometheusMetricsBundle\Metrics');
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS);
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -180,7 +182,7 @@ class AppMetricsTest extends TestCase
 
     public function testUseMetricInfoResolver(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, self::DEFAULT_BUCKETS, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets, new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);
@@ -210,7 +212,7 @@ class AppMetricsTest extends TestCase
             new LabelConfig('client_name', LabelConfig::REQUEST_HEADER, 'X-Client-Name'),
         ];
 
-        $metrics = new AppMetrics(new LabelResolver($labels), self::DEFAULT_BUCKETS, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics(new LabelResolver($labels), $this->defaultBuckets, new DummyMetricInfoResolver());
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -180,6 +180,38 @@ class AppMetricsTest extends TestCase
         );
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSetRequestDurationWithCustomBuckets(): void
+    {
+        self::registerMicrotimeMock('Artprima\PrometheusMetricsBundle\Metrics');
+        $customBuckets = [0.2, 0.6];
+        $metrics = new AppMetrics($this->labelResolver, null, $customBuckets);
+        $metrics->init($this->namespace, $this->collectionRegistry);
+
+        $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $reqEvt = $this->createMock(RequestEvent::class);
+        $reqEvt->method('getRequest')->willReturn($request);
+
+        $response = new Response('', 200);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $evt = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        $metrics->collectStart($reqEvt);
+        $metrics->collectRequest($reqEvt);
+        $metrics->collectResponse($evt);
+        $response = $this->renderer->renderResponse();
+        $content = $response->getContent();
+
+        self::assertStringContainsString('dummy_request_durations_histogram_seconds_bucket{action="all",le="0.2"} 0', $content);
+        self::assertStringContainsString('dummy_request_durations_histogram_seconds_bucket{action="all",le="0.6"} 1', $content);
+        self::assertStringContainsString('dummy_request_durations_histogram_seconds_bucket{action="all",le="+Inf"} 1', $content);
+        self::assertStringContainsString('dummy_request_durations_histogram_seconds_count{action="all"} 1', $content);
+        self::assertStringContainsString('dummy_request_durations_histogram_seconds_sum{action="all"} 0.5', $content);
+        self::assertStringNotContainsString('dummy_request_durations_histogram_seconds_bucket{action="all",le="0.005"}', $content);
+    }
+
     public function testUseMetricInfoResolver(): void
     {
         $metrics = new AppMetrics($this->labelResolver, new DummyMetricInfoResolver(), $this->defaultBuckets);

--- a/Tests/Metrics/AppMetricsTest.php
+++ b/Tests/Metrics/AppMetricsTest.php
@@ -41,7 +41,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequest(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
+        $metrics = new AppMetrics($this->labelResolver, null, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -60,7 +60,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectRequestOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
+        $metrics = new AppMetrics($this->labelResolver, null, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -82,7 +82,7 @@ class AppMetricsTest extends TestCase
 
     public function testCollectResponseOptionsMethod(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
+        $metrics = new AppMetrics($this->labelResolver, null, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'OPTIONS']);
@@ -118,7 +118,7 @@ class AppMetricsTest extends TestCase
      */
     public function testCollectResponse(int $code, string $metricsName): void
     {
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
+        $metrics = new AppMetrics($this->labelResolver, null, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -140,7 +140,7 @@ class AppMetricsTest extends TestCase
     public function testSetRequestDuration(): void
     {
         self::registerMicrotimeMock('Artprima\PrometheusMetricsBundle\Metrics');
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets);
+        $metrics = new AppMetrics($this->labelResolver, null, $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
@@ -182,7 +182,7 @@ class AppMetricsTest extends TestCase
 
     public function testUseMetricInfoResolver(): void
     {
-        $metrics = new AppMetrics($this->labelResolver, $this->defaultBuckets, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics($this->labelResolver, new DummyMetricInfoResolver(), $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);
@@ -212,7 +212,7 @@ class AppMetricsTest extends TestCase
             new LabelConfig('client_name', LabelConfig::REQUEST_HEADER, 'X-Client-Name'),
         ];
 
-        $metrics = new AppMetrics(new LabelResolver($labels), $this->defaultBuckets, new DummyMetricInfoResolver());
+        $metrics = new AppMetrics(new LabelResolver($labels), new DummyMetricInfoResolver(), $this->defaultBuckets);
         $metrics->init($this->namespace, $this->collectionRegistry);
 
         $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET', 'REQUEST_URI' => 'https://example.com/test?query=1']);

--- a/Tests/Metrics/RendererTest.php
+++ b/Tests/Metrics/RendererTest.php
@@ -30,7 +30,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver());
+        $metrics = new AppMetrics(new LabelResolver(), [1]);
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->render();
@@ -46,7 +46,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver());
+        $metrics = new AppMetrics(new LabelResolver(), [1]);
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->renderResponse();

--- a/Tests/Metrics/RendererTest.php
+++ b/Tests/Metrics/RendererTest.php
@@ -30,7 +30,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver(), [1]);
+        $metrics = new AppMetrics(new LabelResolver());
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->render();
@@ -46,7 +46,7 @@ class RendererTest extends TestCase
             ->willReturn([
                 new MetricFamilySamples(self::$samples),
             ]);
-        $metrics = new AppMetrics(new LabelResolver(), [1]);
+        $metrics = new AppMetrics(new LabelResolver());
         $metrics->init('test_ns', $collectionRegistry);
         $renderer = new Renderer($collectionRegistry);
         $response = $renderer->renderResponse();

--- a/demo/symfony-app/test-metrics.php
+++ b/demo/symfony-app/test-metrics.php
@@ -11,6 +11,7 @@ use Artprima\PrometheusMetricsBundle\Metrics\AppMetrics;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelResolver;
 use Artprima\PrometheusMetricsBundle\Metrics\Renderer;
 use Prometheus\CollectorRegistry;
+use Prometheus\Histogram;
 use Prometheus\Storage\InMemory;
 
 echo "🔍 Testing Prometheus Metrics Bundle\n";
@@ -24,7 +25,7 @@ $renderer = new Renderer($registry, 'symfony');
 $labelResolver = new LabelResolver([]);
 
 // Initialize AppMetrics
-$appMetrics = new AppMetrics($labelResolver);
+$appMetrics = new AppMetrics($labelResolver, Histogram::getDefaultBuckets());
 $appMetrics->init('symfony', $registry);
 
 echo "✅ Metrics system initialized\n";

--- a/demo/symfony-app/test-metrics.php
+++ b/demo/symfony-app/test-metrics.php
@@ -25,7 +25,7 @@ $renderer = new Renderer($registry, 'symfony');
 $labelResolver = new LabelResolver([]);
 
 // Initialize AppMetrics
-$appMetrics = new AppMetrics($labelResolver, Histogram::getDefaultBuckets());
+$appMetrics = new AppMetrics($labelResolver, null, Histogram::getDefaultBuckets());
 $appMetrics->init('symfony', $registry);
 
 echo "✅ Metrics system initialized\n";

--- a/demo/test-metrics.php
+++ b/demo/test-metrics.php
@@ -11,6 +11,7 @@ use Artprima\PrometheusMetricsBundle\Metrics\AppMetrics;
 use Artprima\PrometheusMetricsBundle\Metrics\LabelResolver;
 use Artprima\PrometheusMetricsBundle\Metrics\Renderer;
 use Prometheus\CollectorRegistry;
+use Prometheus\Histogram;
 use Prometheus\Storage\InMemory;
 
 echo "🔍 Testing Prometheus Metrics Bundle\n";
@@ -24,7 +25,7 @@ $renderer = new Renderer($registry, 'symfony');
 $labelResolver = new LabelResolver([]);
 
 // Initialize AppMetrics
-$appMetrics = new AppMetrics($labelResolver);
+$appMetrics = new AppMetrics($labelResolver, Histogram::getDefaultBuckets());
 $appMetrics->init('symfony', $registry);
 
 echo "✅ Metrics system initialized\n";

--- a/demo/test-metrics.php
+++ b/demo/test-metrics.php
@@ -25,7 +25,7 @@ $renderer = new Renderer($registry, 'symfony');
 $labelResolver = new LabelResolver([]);
 
 // Initialize AppMetrics
-$appMetrics = new AppMetrics($labelResolver, Histogram::getDefaultBuckets());
+$appMetrics = new AppMetrics($labelResolver, null, Histogram::getDefaultBuckets());
 $appMetrics->init('symfony', $registry);
 
 echo "✅ Metrics system initialized\n";


### PR DESCRIPTION
Recreates the configurable buckets feature from #122 on top of current `master`.

Why this PR exists:
- #122 is no longer mergeable because it conflicts with the current codebase after subsequent refactors and config changes.
- This PR carries the same feature from a clean branch in the maintainer fork so it can be reviewed and merged directly.

Included changes:
- add a `buckets` configuration node with Prometheus default buckets
- inject buckets into `AppMetrics` from the bundle extension
- use configured buckets when registering the request duration histogram
- update tests, demo scripts, and README

Supersedes #122.
