### PR TITLE
Update PHP and Symfony support matrix

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -9,15 +9,15 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    name: PHP 8.1
+    name: PHP 8.2
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: "8.1"
+        php-version: "8.2"
         extensions: mbstring, intl
         ini-values: post_max_size=256M
         coverage: xdebug
@@ -26,12 +26,10 @@ jobs:
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
     - name: Install Composer dependencies
       run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,11 +18,11 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
-    name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
+        php-version: ['8.2', '8.3', '8.4', '8.5']
+    name: PHP ${{ matrix.php-version }} Test on ${{ matrix.operating-system }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # pulls all commits (needed for lerna / semantic release to correctly version)
         fetch-depth: "0"
@@ -33,7 +33,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-version }}
         extensions: mbstring, intl, redis, apcu
         ini-values: post_max_size=256M, apc.enabled=on, apc.enable_cli=on
         coverage: xdebug
@@ -42,12 +42,10 @@ jobs:
       id: composer-cache
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
     - name: Cache composer dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
-        # Use composer.json for key, if composer.lock is not committed.
-        # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
-        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
         restore-keys: ${{ runner.os }}-composer-
     - name: Install Composer dependencies
       run: |

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -88,4 +88,4 @@ jobs:
     - name: Run Integration tests
       run: |
         cd symfony
-        php bin/phpunit
+        vendor/bin/simple-phpunit

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -81,6 +81,9 @@ jobs:
         php .integration/patch.php
         cd symfony
         composer require symfony/phpunit-bridge:${{ matrix.phpunit-bridge-version }} -n --no-progress
+        if [ ! -f bin/phpunit ]; then
+          composer require --dev phpunit/phpunit:^11.5 -n --no-progress
+        fi
         composer require symfony/browser-kit:${{ matrix.symfony-require }} -n --no-progress
         composer require artprima/prometheus-metrics-bundle:* -n --no-progress --no-scripts
         cp -rf ../.integration/symfony/* ./
@@ -88,4 +91,4 @@ jobs:
     - name: Run Integration tests
       run: |
         cd symfony
-        vendor/bin/simple-phpunit
+        php bin/phpunit

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -16,46 +16,73 @@ jobs:
         - 6379:6379
         options: --entrypoint redis-server
     strategy:
+      fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
-        symfony-versions: ['5.4', '6.4', '7.2']
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
-        exclude:
+        include:
           - operating-system: ubuntu-latest
-            symfony-versions: '7.2'
-            php-versions: '8.1'
-    name: PHP ${{ matrix.php-versions }} / Symfony ${{ matrix.symfony-versions }} Test on ${{ matrix.operating-system }}
+            php-version: '8.2'
+            symfony-version: '5.4'
+            symfony-require: '5.4.*'
+            phpunit-bridge-version: '5.4.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.2'
+            symfony-version: '6.4'
+            symfony-require: '6.4.*'
+            phpunit-bridge-version: '6.4.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.5'
+            symfony-version: '6.4'
+            symfony-require: '6.4.*'
+            phpunit-bridge-version: '6.4.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.2'
+            symfony-version: '7.4'
+            symfony-require: '7.4.*'
+            phpunit-bridge-version: '7.4.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.5'
+            symfony-version: '7.4'
+            symfony-require: '7.4.*'
+            phpunit-bridge-version: '7.4.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.4'
+            symfony-version: '8.0'
+            symfony-require: '8.0.*'
+            phpunit-bridge-version: '8.0.*'
+          - operating-system: ubuntu-latest
+            php-version: '8.5'
+            symfony-version: '8.0'
+            symfony-require: '8.0.*'
+            phpunit-bridge-version: '8.0.*'
+    name: PHP ${{ matrix.php-version }} / Symfony ${{ matrix.symfony-version }} Test on ${{ matrix.operating-system }}
+    env:
+      SYMFONY_REQUIRE: ${{ matrix.symfony-require }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: ${{ matrix.php-versions }}
+        php-version: ${{ matrix.php-version }}
         extensions: mbstring, intl, redis
         ini-values: post_max_size=256M
         coverage: xdebug
         tools: php-cs-fixer, phpunit
-    - name: Download Symfony Binary
-      run:  wget https://get.symfony.com/cli/installer -O - | bash
+    - name: Download Symfony CLI
+      run: curl -sS https://get.symfony.com/cli/installer | bash
     - name: Install Symfony
       run: |
-        git config --global user.email "${{ github.actor }}"
-        git config --global user.name ""github-action-${{ github.actor }}@users.noreply.github.com""
-        /home/runner/.symfony5/bin/symfony new symfony --version=${{ matrix.symfony-versions }}
+        $HOME/.symfony5/bin/symfony new symfony --version="${{ matrix.symfony-require }}"
     - name: Configure Symfony to run integration tests
       run: |
         php .integration/patch.php
         cd symfony
-        cat composer.json
-        # Pin phpunit-bridge to 7.2.* to avoid test failures with 7.3+ versions
-        # TODO: upgrading to 7.3 breaks the tests and has to be fixed separately
-        composer require symfony/phpunit-bridge:7.2.* -n --no-progress
-        composer require symfony/browser-kit -n --no-progress
+        composer require symfony/phpunit-bridge:${{ matrix.phpunit-bridge-version }} -n --no-progress
+        composer require symfony/browser-kit:${{ matrix.symfony-require }} -n --no-progress
         composer require artprima/prometheus-metrics-bundle:* -n --no-progress --no-scripts
         cp -rf ../.integration/symfony/* ./
-        composer upgrade -n --no-progress
+        composer update -n --no-progress
     - name: Run Integration tests
       run: |
         cd symfony

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -73,6 +73,8 @@ jobs:
       run: curl -sS https://get.symfony.com/cli/installer | bash
     - name: Install Symfony
       run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
         $HOME/.symfony5/bin/symfony new symfony --version="${{ matrix.symfony-require }}"
     - name: Configure Symfony to run integration tests
       run: |

--- a/README.md
+++ b/README.md
@@ -6,10 +6,24 @@
 | [![Coverage Status][Master coverage image]][Master coverage] |
 
 
-Symfony 5/6/7/8 Prometheus Metrics Bundle
+Symfony 5.4/6.4/7.4/8.x Prometheus Metrics Bundle
 =========================================
 
 A Symfony bundle for the `promphp/prometheus_client_php`.
+
+Supported Versions
+==================
+
+The bundle is currently maintained against these versions:
+
+- PHP: 8.2, 8.3, 8.4, 8.5
+- Symfony: 5.4, 6.4, 7.4, 8.x
+
+Compatibility policy:
+
+- Symfony 5.4 is kept for legacy/LTS compatibility.
+- Symfony 8.x requires PHP 8.4 or newer.
+- CI covers the supported boundaries instead of testing the full Cartesian product of every PHP/Symfony combination.
 
 Installation
 ============

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "artprima/prometheus-metrics-bundle",
-  "description": "Symfony 5/6/7/8 Prometheus Metrics Bundle",
+  "description": "Symfony 5.4/6.4/7.4/8.x Prometheus Metrics Bundle",
   "keywords": [ "symfony", "symfony-bundle", "prometheus", "metrics" ],
   "type": "symfony-bundle",
   "license": "MIT",
@@ -11,20 +11,20 @@
     }
   ],
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "ext-json": "*",
     "promphp/prometheus_client_php": "^2.6",
-    "symfony/http-kernel": "^5.4|^6.4|^7.2|^8.0",
-    "symfony/dependency-injection": "^5.4|^6.4|^7.2|^8.0",
-    "symfony/config": "^5.4|^6.4|^7.2|^8.0"
+    "symfony/http-kernel": "^5.4|^6.4|^7.4|^8.0",
+    "symfony/dependency-injection": "^5.4|^6.4|^7.4|^8.0",
+    "symfony/config": "^5.4|^6.4|^7.4|^8.0"
   },
   "require-dev": {
     "ext-redis": "*",
     "ext-apcu": "*",
-    "phpunit/phpunit": "^10.0",
-    "symfony/yaml": "^5.4|^6.4|^7.2|^8.0",
-    "symfony/browser-kit": "^5.4|^6.4|^7.2|^8.0",
-    "symfony/framework-bundle": "^5.4|^6.4|^7.2|^8.0",
+    "phpunit/phpunit": "^11.5",
+    "symfony/yaml": "^5.4|^6.4|^7.4|^8.0",
+    "symfony/browser-kit": "^5.4|^6.4|^7.4|^8.0",
+    "symfony/framework-bundle": "^5.4|^6.4|^7.4|^8.0",
     "friendsofphp/php-cs-fixer": "^3.75",
     "escapestudios/symfony2-coding-standard": "^3.11",
     "squizlabs/php_codesniffer": "^3.5"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
   <coverage/>
   <php>
     <ini name="error_reporting" value="-1"/>


### PR DESCRIPTION
## Summary
- raise the minimum supported PHP version to 8.2 and replace Symfony 7.2 with Symfony 7.4 in Composer constraints
- refresh the PHP, Symfony, and coding-style workflows to cover supported PHP/Symfony combinations and remove EOL versions
- document the maintained support matrix in the README and align the PHPUnit XML schema with the updated test dependency

## Validation
- validated `composer.json` and `phpunit.xml.dist` parse successfully
- validated `.github/workflows/php.yml`, `.github/workflows/code-style.yml`, and `.github/workflows/symfony.yml` parse successfully
- full PHP/Composer/test execution was not run in this environment
