### PR TITLE
Fix BC break introduced in 1.22.0 by restoring the `TerminateMetricsCollectorInterface`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 * 1.22.1 (2026-05-21)
 
-  * Restore deprecated `TerminateMetricsCollectorInterface` to fix BC break introduced in 1.22.0 ([#131](https://github.com/artprima/prometheus-metrics-bundle/pull/131)). Implement `ResponseMetricsCollectorInterface` instead.
+  * Restore deprecated `TerminateMetricsCollectorInterface` to fix BC break introduced in 1.22.0 ([#131](https://github.com/artprima/prometheus-metrics-bundle/pull/131)) ([#140](https://github.com/artprima/prometheus-metrics-bundle/pull/140)). Implement `ResponseMetricsCollectorInterface` instead.
 
 * 1.22.0 (2026-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+* 1.22.1 (2026-05-21)
+
+  * Restore deprecated `TerminateMetricsCollectorInterface` to fix BC break introduced in 1.22.0 ([#131](https://github.com/artprima/prometheus-metrics-bundle/pull/131)). Implement `ResponseMetricsCollectorInterface` instead.
+
 * 1.22.0 (2026-05-20)
 
   * Add support for configurable histogram buckets (supersedes [#122](https://github.com/artprima/prometheus-metrics-bundle/pull/122)) ([#136](https://github.com/artprima/prometheus-metrics-bundle/pull/136))

--- a/EventListener/MetricsCollectorListener.php
+++ b/EventListener/MetricsCollectorListener.php
@@ -174,7 +174,7 @@ class MetricsCollectorListener implements LoggerAwareInterface
     }
 
     /**
-     * @deprecated Will be removed once TerminateMetricsCollectorInterface is dropped.
+     * @deprecated will be removed once TerminateMetricsCollectorInterface is dropped
      */
     public function onKernelTerminate(TerminateEvent $event): void
     {
@@ -188,7 +188,7 @@ class MetricsCollectorListener implements LoggerAwareInterface
         }
 
         foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
-            if (!($collector instanceof TerminateMetricsCollectorInterface)) {
+            if (!$collector instanceof TerminateMetricsCollectorInterface) {
                 continue;
             }
 

--- a/EventListener/MetricsCollectorListener.php
+++ b/EventListener/MetricsCollectorListener.php
@@ -14,6 +14,7 @@ use Artprima\PrometheusMetricsBundle\Metrics\PreExceptionMetricsCollectorInterfa
 use Artprima\PrometheusMetricsBundle\Metrics\PreRequestMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\RequestMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\ResponseMetricsCollectorInterface;
+use Artprima\PrometheusMetricsBundle\Metrics\TerminateMetricsCollectorInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
  * Class MetricsCollectorListener is an event listener that calls the registered metric handlers.
@@ -149,9 +151,51 @@ class MetricsCollectorListener implements LoggerAwareInterface
         }
 
         foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
+            // BC layer for deprecated TerminateMetricsCollectorInterface
+            // TerminateMetricsCollectorInterface::collectResponse() takes TerminateEvent, not ResponseEvent
+            if ($collector instanceof TerminateMetricsCollectorInterface && !($collector instanceof ResponseMetricsCollectorInterface)) {
+                continue;
+            }
             if (!self::isSupportedEvent($collector, 'collectResponse', ResponseMetricsCollectorInterface::class)) {
                 continue;
             }
+
+            try {
+                $collector->collectResponse($event);
+            } catch (\Exception $e) {
+                if ($this->logger) {
+                    $this->logger->error(
+                        $e->getMessage(),
+                        ['from' => 'response_collector', 'class' => $collector::class]
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * @deprecated Will be removed once TerminateMetricsCollectorInterface is dropped.
+     */
+    public function onKernelTerminate(TerminateEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $requestRoute = $event->getRequest()->attributes->get('_route');
+        if (in_array($requestRoute, $this->ignoredRoutes, true)) {
+            return;
+        }
+
+        foreach ($this->metricsCollectors->getMetricsCollectors() as $collector) {
+            if (!($collector instanceof TerminateMetricsCollectorInterface)) {
+                continue;
+            }
+
+            @trigger_error(sprintf(
+                '%s implements deprecated TerminateMetricsCollectorInterface. Implement ResponseMetricsCollectorInterface instead.',
+                $collector::class
+            ), \E_USER_DEPRECATED);
 
             try {
                 $collector->collectResponse($event);

--- a/Metrics/TerminateMetricsCollectorInterface.php
+++ b/Metrics/TerminateMetricsCollectorInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Artprima\PrometheusMetricsBundle\Metrics;
+
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+
+/**
+ * @deprecated Use ResponseMetricsCollectorInterface instead.
+ */
+interface TerminateMetricsCollectorInterface extends MetricsCollectorInterface
+{
+    public function collectResponse(TerminateEvent $event): void;
+}

--- a/Metrics/TerminateMetricsCollectorInterface.php
+++ b/Metrics/TerminateMetricsCollectorInterface.php
@@ -7,7 +7,7 @@ namespace Artprima\PrometheusMetricsBundle\Metrics;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 
 /**
- * @deprecated Use ResponseMetricsCollectorInterface instead.
+ * @deprecated use ResponseMetricsCollectorInterface instead
  */
 interface TerminateMetricsCollectorInterface extends MetricsCollectorInterface
 {

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -23,6 +23,7 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.request }
       - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority: 1024 }
+      - { name: kernel.event_listener, event: kernel.terminate, method: onKernelTerminate, priority: 1024 }
       - { name: kernel.event_listener, event: kernel.request, method: onKernelRequestPre, priority: 1024 }
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelExceptionPre }
       - { name: kernel.event_listener, event: kernel.exception, method: onKernelException, priority: 1024 }

--- a/Tests/EventListener/LegacyTerminateCollectorStub.php
+++ b/Tests/EventListener/LegacyTerminateCollectorStub.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Artprima\PrometheusMetricsBundle\EventListener;
+
+use Artprima\PrometheusMetricsBundle\Metrics\TerminateMetricsCollectorInterface;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
+
+class LegacyTerminateCollectorStub implements TerminateMetricsCollectorInterface
+{
+    public function collectResponse(TerminateEvent $event): void
+    {
+    }
+
+    public function init(string $namespace, \Prometheus\CollectorRegistry $collectionRegistry): void
+    {
+    }
+}

--- a/Tests/EventListener/MetricsCollectorListenerTest.php
+++ b/Tests/EventListener/MetricsCollectorListenerTest.php
@@ -30,6 +30,17 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+class LegacyTerminateCollectorStub implements TerminateMetricsCollectorInterface
+{
+    public function collectResponse(TerminateEvent $event): void
+    {
+    }
+
+    public function init(string $namespace, \Prometheus\CollectorRegistry $collectionRegistry): void
+    {
+    }
+}
+
 class MetricsCollectorListenerTest extends TestCase
 {
     public function testOnKernelRequest(): void
@@ -251,7 +262,27 @@ class MetricsCollectorListenerTest extends TestCase
         $registry->registerMetricsCollector($collector2);
 
         $listener = new MetricsCollectorListener($registry);
-        @$listener->onKernelTerminate($evt);
+        $listener->onKernelTerminate($evt);
+    }
+
+    public function testOnKernelTerminateTriggersDeprecation(): void
+    {
+        $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $response = new Response('', 200);
+        $evt = new TerminateEvent($kernel, $request, $response);
+
+        $collector = new LegacyTerminateCollectorStub();
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($collector);
+
+        $listener = new MetricsCollectorListener($registry);
+
+        $this->expectUserDeprecationMessage(
+            LegacyTerminateCollectorStub::class.' implements deprecated TerminateMetricsCollectorInterface. Implement ResponseMetricsCollectorInterface instead.'
+        );
+        $listener->onKernelTerminate($evt);
     }
 
     public function testOnKernelTerminateIgnoredRoute(): void
@@ -268,7 +299,7 @@ class MetricsCollectorListenerTest extends TestCase
         $registry->registerMetricsCollector($collector1);
 
         $listener = new MetricsCollectorListener($registry, ['test_route']);
-        @$listener->onKernelTerminate($evt);
+        $listener->onKernelTerminate($evt);
     }
 
     public function testOnKernelResponseSkipsTerminateOnlyCollector(): void

--- a/Tests/EventListener/MetricsCollectorListenerTest.php
+++ b/Tests/EventListener/MetricsCollectorListenerTest.php
@@ -13,6 +13,7 @@ use Artprima\PrometheusMetricsBundle\Metrics\MetricsCollectorRegistry;
 use Artprima\PrometheusMetricsBundle\Metrics\PreExceptionMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\RequestMetricsCollectorInterface;
 use Artprima\PrometheusMetricsBundle\Metrics\ResponseMetricsCollectorInterface;
+use Artprima\PrometheusMetricsBundle\Metrics\TerminateMetricsCollectorInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
@@ -26,6 +27,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class MetricsCollectorListenerTest extends TestCase
@@ -230,6 +232,66 @@ class MetricsCollectorListenerTest extends TestCase
 
         $listener = new MetricsCollectorListener($registry);
         $listener->onKernelExceptionPre($evt);
+    }
+
+    public function testOnKernelTerminate(): void
+    {
+        $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $response = new Response('', 200);
+        $evt = new TerminateEvent($kernel, $request, $response);
+
+        $collector1 = $this->createMock(TerminateMetricsCollectorInterface::class);
+        $collector1->expects(self::once())->method('collectResponse')->with($evt);
+        $collector2 = $this->createMock(TerminateMetricsCollectorInterface::class);
+        $collector2->expects(self::once())->method('collectResponse')->with($evt);
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($collector1);
+        $registry->registerMetricsCollector($collector2);
+
+        $listener = new MetricsCollectorListener($registry);
+        @$listener->onKernelTerminate($evt);
+    }
+
+    public function testOnKernelTerminateIgnoredRoute(): void
+    {
+        $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $response = new Response('', 200);
+        $evt = new TerminateEvent($kernel, $request, $response);
+
+        $collector1 = $this->createMock(TerminateMetricsCollectorInterface::class);
+        $collector1->expects(self::never())->method('collectResponse');
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($collector1);
+
+        $listener = new MetricsCollectorListener($registry, ['test_route']);
+        @$listener->onKernelTerminate($evt);
+    }
+
+    public function testOnKernelResponseSkipsTerminateOnlyCollector(): void
+    {
+        $request = new Request([], [], ['_route' => 'test_route'], [], [], ['REQUEST_METHOD' => 'GET']);
+        $kernel = $this->createMock(HttpKernelInterface::class);
+        $response = new Response('', 200);
+        $evt = new ResponseEvent($kernel, $request, HttpKernelInterface::MAIN_REQUEST, $response);
+
+        // A collector implementing only the deprecated interface must NOT be called in onKernelResponse
+        // because its collectResponse() expects a TerminateEvent, not a ResponseEvent.
+        $oldCollector = $this->createMock(TerminateMetricsCollectorInterface::class);
+        $oldCollector->expects(self::never())->method('collectResponse');
+
+        $newCollector = $this->createMock(ResponseMetricsCollectorInterface::class);
+        $newCollector->expects(self::once())->method('collectResponse')->with($evt);
+
+        $registry = new MetricsCollectorRegistry();
+        $registry->registerMetricsCollector($oldCollector);
+        $registry->registerMetricsCollector($newCollector);
+
+        $listener = new MetricsCollectorListener($registry);
+        $listener->onKernelResponse($evt);
     }
 
     public function testOnConsoleCommand(): void

--- a/Tests/EventListener/MetricsCollectorListenerTest.php
+++ b/Tests/EventListener/MetricsCollectorListenerTest.php
@@ -30,17 +30,6 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class LegacyTerminateCollectorStub implements TerminateMetricsCollectorInterface
-{
-    public function collectResponse(TerminateEvent $event): void
-    {
-    }
-
-    public function init(string $namespace, \Prometheus\CollectorRegistry $collectionRegistry): void
-    {
-    }
-}
-
 class MetricsCollectorListenerTest extends TestCase
 {
     public function testOnKernelRequest(): void


### PR DESCRIPTION
Fix BC break introduced in #131 by restoring the `TerminateMetricsCollectorInterface` and adding BC layer to support old and new interfaces.

_I didn't test these changes with my app yet. But if you can verify them, feel free to merge_